### PR TITLE
Zen 355 styles fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ ios/platform.sqlite
 **/clients/**/temp
 
 /temp_assets
+src/assets/fonts
 /builds/*
 /bundle
 jsconfig.json

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "clean:sessions:build": "rimraf ./build/*",
     "ios": "yarn watch 'cd node_modules/keg-core; yarn ios'",
     "setup": "yarn install; cd node_modules/keg-core; yarn postinstall",
-    "start": "yarn watch 'cd node_modules/keg-core; expo start'",
+    "start": "cd node_modules/keg-core; expo start",
     "watch": "nodemon --watch node_modules/keg-core/core/base/configs --watch node_modules/keg-core/app.json --watch node_modules/keg-core/package.json --watch configs --watch package.json --watch tap.json --exec",
     "web": "cd node_modules/keg-core; yarn web",
     "test:build": "yarn build && TEST_BUILD=true yarn web",

--- a/src/assets/icons/evf/elements/dayToggleLeft.js
+++ b/src/assets/icons/evf/elements/dayToggleLeft.js
@@ -1,14 +1,22 @@
-import * as React from 'react'
+import React, { useMemo } from 'react'
 import Svg, { Path } from 'react-native-svg'
 
 export function DayToggleLeft(props) {
+  const { style } = props
+
+  const dimStyles = useMemo(() => {
+    return {
+      height: style?.height || style?.fontSize || 17,
+      width: style?.width || style?.fontSize || 10,
+    }
+  }, [ style?.height, style?.width, style?.fontSize ])
+
   return (
     <Svg
-      width={10}
-      height={17}
       viewBox='0 0 10 17'
       fill='none'
       {...props}
+      style={[ style, dimStyles ]}
     >
       <Path
         d='M9.648.319a1.17 1.17 0 00-1.605 0l-7.711 7.4a1.061 1.061 0 000 1.542l7.71 7.4a1.17 1.17 0 001.606.039c.454-.414.47-1.103.04-1.542l-.04-.038-6.911-6.63 6.908-6.63A1.059 1.059 0 009.648.32c.003.002 0 0 0 0z'

--- a/src/assets/icons/evf/elements/dayToggleRight.js
+++ b/src/assets/icons/evf/elements/dayToggleRight.js
@@ -1,14 +1,22 @@
-import * as React from 'react'
+import React, { useMemo } from 'react'
 import Svg, { Path } from 'react-native-svg'
 
 export function DayToggleRight(props) {
+  const { style } = props
+
+  const dimStyles = useMemo(() => {
+    return {
+      height: style?.height || style?.fontSize || 17,
+      width: style?.width || style?.fontSize || 10,
+    }
+  }, [ style?.height, style?.width, style?.fontSize ])
+
   return (
     <Svg
-      width={10}
-      height={17}
       viewBox='0 0 10 17'
       fill='none'
       {...props}
+      style={[ style, dimStyles ]}
     >
       <Path
         d='M.352 16.681a1.17 1.17 0 001.605 0l7.711-7.4a1.061 1.061 0 000-1.542l-7.71-7.4A1.17 1.17 0 00.351.3a1.062 1.062 0 000 1.58l6.911 6.63-6.908 6.63a1.059 1.059 0 00-.003 1.541c-.003-.002 0 0 0 0z'

--- a/src/components/button/evfButton.js
+++ b/src/components/button/evfButton.js
@@ -9,17 +9,16 @@ import { useParsedStyle } from 'SVHooks/useParsedStyle'
  */
 const buildStyles = (theme, custom) => {
   const btnStyles = theme.get(`button.evfButton.${custom.type}`)
-  // const parsedState = { main: custom.parsed }
-  // console.log('parsedState', parsedState)
+  const parsedState = { main: custom.parsed }
 
   return theme.get(btnStyles, custom.styles, {
-    // content: {
-    //   button: {
-    //     active: parsedState,
-    //     default: parsedState,
-    //     hover: parsedState,
-    //   },
-    // },
+    content: {
+      button: {
+        active: parsedState,
+        default: parsedState,
+        hover: parsedState,
+      },
+    },
   })
 }
 

--- a/src/components/dates/dayToggle.js
+++ b/src/components/dates/dayToggle.js
@@ -46,7 +46,7 @@ export const DayToggle = props => {
       style={dayToggleStyles?.main}
     >
       <UpdateDayButton
-        style={dayToggleStyles?.content?.decrementIcon}
+        styles={dayToggleStyles?.content?.decrement}
         type={'decrement'}
         disabled={disableDecrement}
         onDayChange={onDecrement}
@@ -62,7 +62,7 @@ export const DayToggle = props => {
 
       <UpdateDayButton
         type={'increment'}
-        style={dayToggleStyles?.content?.incrementIcon}
+        styles={dayToggleStyles?.content?.increment}
         disabled={disableIncrement}
         onDayChange={onIncrement}
       />

--- a/src/components/dates/updateDayButton.js
+++ b/src/components/dates/updateDayButton.js
@@ -9,11 +9,13 @@ import PropTypes from 'prop-types'
  * @param {object} theme - retheme object
  * @param {object} extra - extra styles and props
  */
-const buildStyles = (theme, extra) => ({
-  opacity: extra.disabled ? 0.4 : 1,
-  cursor: extra.disabled ? 'not-allowed' : 'pointer',
-  ...extra.style,
-})
+const buildStyles = (theme, extra) => {
+  return {
+    ...extra?.style?.icon,
+    opacity: extra.disabled ? 0.4 : 1,
+    cursor: extra.disabled ? 'not-allowed' : 'pointer',
+  }
+}
 
 /**
  * A touchable chevron icon that changes direction based on type
@@ -31,9 +33,9 @@ export const UpdateDayButton = props => {
     onDayChange,
   } = props
 
-  const iconStyles = useStylesCallback(buildStyles, [ disabled, styles.main ], {
+  const iconStyles = useStylesCallback(buildStyles, [ disabled, styles ], {
     disabled,
-    style: styles.main,
+    style: styles,
   })
 
   const ChevronIcon =

--- a/src/components/hocs/withAppHeader.js
+++ b/src/components/hocs/withAppHeader.js
@@ -30,7 +30,6 @@ export const withAppHeader = (title, Component) => {
               : null
           }
         />
-
         <Component {...props} />
       </>
     )

--- a/src/components/sessions.js
+++ b/src/components/sessions.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useCallback, useMemo } from 'react'
 import { useTheme, useDimensions } from '@keg-hub/re-theme'
-import { View, ItemHeader, Button } from '@keg-hub/keg-components'
+import { View, ItemHeader, Button, ScrollView } from '@keg-hub/keg-components'
 import { RenderModals } from 'SVComponents/modals/renderModals'
 import { mapSessionInterface } from 'SVActions/session/mapSessionInterface'
 import { incrementDay, decrementDay } from 'SVActions/session/dates'
@@ -107,20 +107,23 @@ const AgendaSessions = React.memo(
   ({ labels, daySessions, enableFreeLabel }) => {
     if (!daySessions) return null
 
-    return mapObj(daySessions, (timeBlock, sessions) => {
-      return (
-        // creates a gridContainer separated by hour blocks
-        <GridContainer
-          key={timeBlock}
-          sessions={sessions}
-          labels={labels}
-          timeBlock={timeBlock}
-          enableFreeLabel={enableFreeLabel}
-        />
-      )
-    })
-  }
-)
+  return (
+    <ScrollView>
+      { mapObj(daySessions, (timeBlock, sessions) => {
+        return (
+          // creates a gridContainer separated by hour blocks
+          <GridContainer
+            key={timeBlock}
+            sessions={sessions}
+            labels={labels}
+            timeBlock={timeBlock}
+            enableFreeLabel={enableFreeLabel}
+          />
+        )
+      }) }
+    </ScrollView>
+  )
+})
 
 /**
  * SessionComponent

--- a/src/components/sessions.js
+++ b/src/components/sessions.js
@@ -87,7 +87,7 @@ const SessionsHeader = ({ styles, onDayChange, labels }) => {
       }
       RightComponent={
         <FilterButton
-          styles={headerStyles.content?.right}
+          styles={headerStyles?.content?.right}
           onClick={displayFilterModal}
         />
       }

--- a/src/containers/gridContainer.js
+++ b/src/containers/gridContainer.js
@@ -57,7 +57,7 @@ export const GridContainer = props => {
             LeftComponent={
               <LeftHeaderText
                 timeString={timeBlock}
-                style={gridStyles.content.header.content.left}
+                style={gridStyles?.content?.header?.content?.left}
               />
             }
           />
@@ -65,7 +65,7 @@ export const GridContainer = props => {
       }
       <View
         className={`ef-grid-item`}
-        style={gridStyles.content.items}
+        style={gridStyles?.content?.items}
       >
         { sessions &&
           sessions.map(session => (

--- a/src/containers/rootContainer.js
+++ b/src/containers/rootContainer.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { withAppHeader } from 'SVComponents'
-import { SessionsContainer } from 'SVContainers'
+import { SessionsContainer } from './sessionsContainer'
 import { displayName } from 'SVConfig'
 import { H5 } from '@keg-hub/keg-components'
 import testData from '../mocks/eventsforce/testData.json'

--- a/src/theme/components/button/evfButton.js
+++ b/src/theme/components/button/evfButton.js
@@ -28,12 +28,12 @@ const defaultButtonStyles = {
   },
   content: {
     $xsmall: {
-      letterSpacing: '0.105em',
+      letterSpacing: 0.105,
       fontWeight: 'bold',
       color: colors.white,
       fontSize: 13,
       paddingHorizontal: 8,
-      lineHeight: '18px',
+      lineHeight: 18,
     },
     $small: {
       fontSize: 15,

--- a/src/theme/components/button/evfButton.js
+++ b/src/theme/components/button/evfButton.js
@@ -2,15 +2,21 @@ import { colors } from '../../colors'
 
 const topLeftCornerStyle = {
   main: {
-    width: 25,
-    height: 25,
-    backgroundColor: colors.white,
-    position: 'absolute',
-    overflow: 'hidden',
-    left: '-13px',
-    top: '-13px',
-    zIndex: 9999,
-    transform: [{ rotate: '45deg' }],
+    $web: {
+      left: '-13px',
+      top: '-13px',
+    },
+    $all: {
+      left: -13,
+      top: -13,
+      width: 25,
+      height: 25,
+      backgroundColor: colors.white,
+      position: 'absolute',
+      overflow: 'hidden',
+      zIndex: 9999,
+      transform: [{ rotate: '45deg' }],
+    },
   },
 }
 

--- a/src/theme/components/dates/dayToggle.js
+++ b/src/theme/components/dates/dayToggle.js
@@ -1,8 +1,8 @@
 import { colors } from '../../colors'
 
 export const dayToggle = {
-  $web: {
-    main: {
+  main: {
+    $all: {
       $xsmall: {
         flexDirection: 'row',
         alignItems: 'center',
@@ -12,16 +12,39 @@ export const dayToggle = {
         width: 300,
       },
     },
-    content: {
-      text: {
+    $native: {
+      $xsmall: {
+        width: '100%',
+        justifyContent: 'flex-start',
+      },
+    },
+  },
+  content: {
+    text: {
+      $native: {
         $xsmall: {
-          letterSpacing: '0.1em',
+          marginLeft: 45,
+          marginRight: 45,
+          fontSize: 20,
+        },
+      },
+      $all: {
+        $xsmall: {
+          letterSpacing: 0.1,
           textDecorationLine: 'underline',
-          fontFamily: 'Inter',
           fontStyle: 'normal',
           fontWeight: '500',
-          fontSize: '18px',
           color: colors.black01,
+        },
+        $small: {
+          fontSize: 20,
+        },
+      },
+      $web: {
+        $xsmall: {
+          fontFamily: 'Inter',
+          fontSize: '18px',
+          letterSpacing: '0.1em',
           marginLeft: 10,
           marginRight: 16,
         },
@@ -29,11 +52,19 @@ export const dayToggle = {
           fontSize: '20px',
         },
       },
-      decrementIcon: {
-        main: {},
+    },
+    decrement: {
+      icon: {
+        $native: {
+          fontSize: 20,
+        },
       },
-      incrementIcon: {
-        main: {},
+    },
+    increment: {
+      icon: {
+        $native: {
+          fontSize: 20,
+        },
       },
     },
   },

--- a/src/theme/components/grid/gridItem.js
+++ b/src/theme/components/grid/gridItem.js
@@ -21,6 +21,8 @@ export const gridItem = {
       minHeight: 294,
     },
   },
+  gridTileContent,
+  gridRowContent,
   sessionTime: {
     main: {
       $web: {
@@ -31,11 +33,7 @@ export const gridItem = {
         flexDirection: 'row',
         alignSelf: 'flex-start',
       },
-    },
-    gridTileContent,
-    gridRowContent,
-    sessionTime: {
-      main: {
+      $all: {
         marginTop: 13,
       },
     },

--- a/src/theme/components/grid/gridItem.js
+++ b/src/theme/components/grid/gridItem.js
@@ -3,23 +3,33 @@ import { gridTileContent } from './gridTileContent'
 import { gridRowContent } from './gridRowContent'
 
 export const gridItem = {
-  $web: {
+  main: {
+    $xsmall: {
+      backgroundColor: colors.white,
+      height: 200,
+      marginBottom: 15,
+      alignItems: 'flex-start',
+    },
+    $small: {
+      flex: 1,
+      marginHorizontal: 3,
+      marginBottom: 6,
+      padding: 15,
+      paddingTop: 20,
+      flexBasis: 333,
+      flexDirection: 'column',
+      minHeight: 294,
+    },
+  },
+  sessionTime: {
     main: {
-      $xsmall: {
-        backgroundColor: colors.white,
-        height: 200,
-        marginBottom: 15,
-        alignItems: 'flex-start',
+      $web: {
+        height: 'fit-content',
+        fontFamily: 'Inter',
       },
-      $small: {
-        flex: 1,
-        marginHorizontal: 3,
-        marginBottom: 6,
-        padding: 15,
-        paddingTop: 20,
-        flexBasis: 333,
-        flexDirection: 'column',
-        minHeight: 294,
+      $native: {
+        flexDirection: 'row',
+        alignSelf: 'flex-start',
       },
     },
     gridTileContent,
@@ -27,29 +37,28 @@ export const gridItem = {
     sessionTime: {
       main: {
         marginTop: 13,
-        height: 'fit-content',
       },
     },
-    label: {
-      main: {
-        $xsmall: {
-          margin: 0,
-        },
-        $small: {
-          marginTop: 8,
-          marginRight: 8,
-        },
+  },
+  label: {
+    main: {
+      $xsmall: {
+        margin: 0,
+      },
+      $small: {
+        marginTop: 8,
+        marginRight: 8,
       },
     },
-    labelList: {
-      main: {
-        $xsmall: {
-          marginRight: 14,
-          flex: 1,
-        },
-        $small: {
-          marginRight: 0,
-        },
+  },
+  labelList: {
+    main: {
+      $xsmall: {
+        marginRight: 14,
+        flex: 1,
+      },
+      $small: {
+        marginRight: 0,
       },
     },
   },

--- a/src/theme/components/labelButton.js
+++ b/src/theme/components/labelButton.js
@@ -3,17 +3,26 @@ const contentStyle = {
   fontWeight: 500,
 }
 const mainStyle = {
-  $xsmall: {
-    margin: 0,
-    width: 'fit-content',
-    minHeight: 30,
-    height: 30,
-    borderRadius: 2,
-    justifyContent: 'center',
+  $web: {
+    $xsmall: {
+      width: 'fit-content',
+    }
   },
-  $small: {
-    marginTop: 8,
-    marginRight: 8,
+  $all: {
+    $xsmall: {
+      minHeight: 30,
+      height: 30,
+      borderRadius: 2,
+      justifyContent: 'center',
+      margin: 0,
+      flexDirection: 'row',
+      alignSelf: 'flex-start',
+      borderRadius: 2,
+    },
+    $small: {
+      marginTop: 8,
+      marginRight: 8,
+    },
   },
 }
 
@@ -29,17 +38,13 @@ const styleWithOpacity = opacity => {
 
 export const labelButton = {
   selected: {
-    $web: {
-      default: styleWithOpacity(),
-      hover: styleWithOpacity(),
-      active: styleWithOpacity(),
-    },
+    default: styleWithOpacity(),
+    hover: styleWithOpacity(),
+    active: styleWithOpacity(),
   },
   unselected: {
-    $web: {
-      default: styleWithOpacity(0.4),
-      hover: styleWithOpacity(0.4),
-      active: styleWithOpacity(0.4),
-    },
+    default: styleWithOpacity(0.4),
+    hover: styleWithOpacity(0.4),
+    active: styleWithOpacity(0.4),
   },
 }

--- a/src/theme/components/labelButton.js
+++ b/src/theme/components/labelButton.js
@@ -1,28 +1,19 @@
 const contentStyle = {
   fontSize: 12,
-  fontWeight: 500,
+  fontWeight: '500',
 }
 const mainStyle = {
-  $web: {
-    $xsmall: {
-      width: 'fit-content',
-    }
+  $xsmall: {
+    margin: 0,
+    width: 'fit-content',
+    minHeight: 30,
+    height: 30,
+    borderRadius: 2,
+    justifyContent: 'center',
   },
-  $all: {
-    $xsmall: {
-      minHeight: 30,
-      height: 30,
-      borderRadius: 2,
-      justifyContent: 'center',
-      margin: 0,
-      flexDirection: 'row',
-      alignSelf: 'flex-start',
-      borderRadius: 2,
-    },
-    $small: {
-      marginTop: 8,
-      marginRight: 8,
-    },
+  $small: {
+    marginTop: 8,
+    marginRight: 8,
   },
 }
 
@@ -38,13 +29,17 @@ const styleWithOpacity = opacity => {
 
 export const labelButton = {
   selected: {
-    default: styleWithOpacity(),
-    hover: styleWithOpacity(),
-    active: styleWithOpacity(),
+    $web: {
+      default: styleWithOpacity(),
+      hover: styleWithOpacity(),
+      active: styleWithOpacity(),
+    },
   },
   unselected: {
-    default: styleWithOpacity(0.4),
-    hover: styleWithOpacity(0.4),
-    active: styleWithOpacity(0.4),
+    $web: {
+      default: styleWithOpacity(0.4),
+      hover: styleWithOpacity(0.4),
+      active: styleWithOpacity(0.4),
+    },
   },
 }

--- a/src/theme/components/labelButton.js
+++ b/src/theme/components/labelButton.js
@@ -3,17 +3,27 @@ const contentStyle = {
   fontWeight: '500',
 }
 const mainStyle = {
-  $xsmall: {
-    margin: 0,
-    width: 'fit-content',
-    minHeight: 30,
-    height: 30,
-    borderRadius: 2,
-    justifyContent: 'center',
+  $web: {
+    $xsmall: {
+      width: 'fit-content',
+    },
   },
-  $small: {
-    marginTop: 8,
-    marginRight: 8,
+  $native: {
+    flexDirection: 'row',
+    alignSelf: 'flex-start',
+  },
+  $all: {
+    $xsmall: {
+      margin: 0,
+      minHeight: 30,
+      height: 30,
+      borderRadius: 2,
+      justifyContent: 'center',
+    },
+    $small: {
+      marginTop: 8,
+      marginRight: 8,
+    },
   },
 }
 

--- a/src/theme/components/labelButton.js
+++ b/src/theme/components/labelButton.js
@@ -31,7 +31,13 @@ const styleWithOpacity = opacity => {
   return {
     main: {
       ...mainStyle,
-      opacity,
+      $all: {
+        ...mainStyle.$all,
+        $xsmall: {
+          ...mainStyle.$all.$xsmall,
+          opacity,
+        },
+      },
     },
     content: contentStyle,
   }

--- a/src/theme/components/labelList.js
+++ b/src/theme/components/labelList.js
@@ -3,6 +3,10 @@ export const labelList = {
     $web: {
       height: 'fit-content',
     },
+    $native: {
+      flexDirection: 'row',
+      alignSelf: 'flex-start',
+    },
     $all: {
       $xsmall: {
         flexDirection: 'column',
@@ -13,8 +17,6 @@ export const labelList = {
         flexDirection: 'row',
         alignContent: 'flex-start',
         flexWrap: 'wrap',
-        flexDirection: 'row',
-        alignSelf: 'flex-start',
         maxWidth: '100%',
         flexBasis: 'auto',
       },

--- a/src/theme/components/labelList.js
+++ b/src/theme/components/labelList.js
@@ -1,6 +1,9 @@
 export const labelList = {
-  $web: {
-    main: {
+  main: {
+    $web: {
+      height: 'fit-content',
+    },
+    $all: {
       $xsmall: {
         flexDirection: 'column',
         height: '100%',
@@ -10,7 +13,8 @@ export const labelList = {
         flexDirection: 'row',
         alignContent: 'flex-start',
         flexWrap: 'wrap',
-        height: 'fit-content',
+        flexDirection: 'row',
+        alignSelf: 'flex-start',
         maxWidth: '100%',
         flexBasis: 'auto',
       },

--- a/src/theme/components/labelTag.js
+++ b/src/theme/components/labelTag.js
@@ -1,9 +1,7 @@
 export const labelTag = {
-  $web: {
-    main: {
-      flex: 1,
-      margin: 0,
-      width: 10,
-    },
+  main: {
+    flex: 1,
+    margin: 0,
+    width: 10,
   },
 }

--- a/src/theme/components/modals/baseModal.js
+++ b/src/theme/components/modals/baseModal.js
@@ -2,16 +2,23 @@ import { colors } from '../../colors'
 
 export const defaultTextStyle = {
   fontWeight: '600',
-  fontSize: '16px',
+  fontSize: 16,
 }
 
 export const baseModal = {
   main: {},
   content: {
     main: {
-      $xsmall: {
-        width: '90%',
-        maxWidth: '650px',
+      $web: {
+        $xsmall: {
+          maxWidth: '650px',
+        },
+      },
+      $all: {
+        $xsmall: {
+          width: '90%',
+          maxWidth: 650,
+        },
       },
     },
     header: {
@@ -27,7 +34,7 @@ export const baseModal = {
             color: colors.white,
             paddingLeft: 46,
             paddingRight: 30,
-            fontWeight: 600,
+            fontWeight: '600',
             fontSize: 18,
             lineHeight: 27,
           },

--- a/src/theme/components/modals/errorModal.js
+++ b/src/theme/components/modals/errorModal.js
@@ -2,19 +2,33 @@ export const errorModal = {
   main: {},
   content: {
     main: {
-      $xsmall: {
-        minHeight: 200,
-        width: '80%',
-        maxWidth: '600px',
+      $web: {
+        $xsmall: {
+          maxWidth: '600px',
+        },
+      },
+      $all: {
+        $xsmall: {
+          minHeight: 200,
+          width: '80%',
+          maxWidth: 600,
+        },
       },
     },
     header: {
       content: {
         title: {
-          $xsmall: {
-            letterSpacing: '0.105em',
+          $web: {
+            $xsmall: {
+              letterSpacing: '0.105em',
+            },
           },
-          $small: {},
+          $all: {
+            $xsmall: {
+              letterSpacing: 0.105,
+            },
+            $small: {},
+          },
         },
       },
     },
@@ -25,8 +39,13 @@ export const errorModal = {
       },
       content: {
         text: {
-          fontSize: '16px',
-          paddingBottom: 10,
+          $web: {
+            fontSize: '16px',
+          },
+          $all: {
+            fontSize: 16,
+            paddingBottom: 10,
+          },
         },
         button: {
           main: {

--- a/src/theme/components/modals/filterModal.js
+++ b/src/theme/components/modals/filterModal.js
@@ -72,17 +72,24 @@ const labelButton = {
 }
 
 const buttonsWrapper = {
-  $xsmall: {
-    flexDirection: 'row',
-    alignContent: 'flex-start',
-    flexWrap: 'wrap',
+  $web: {
     height: 'fit-content',
-    maxWidth: '100%',
-    flexBasis: 'auto',
-    paddingBottom: 20,
   },
-  $small: {
-    paddingBottom: 60,
+  $native: {
+    alignSelf: 'flex-start',
+  },
+  $all: {
+    $xsmall: {
+      flexDirection: 'row',
+      alignContent: 'flex-start',
+      flexWrap: 'wrap',
+      maxWidth: '100%',
+      flexBasis: 'auto',
+      paddingBottom: 20,
+    },
+    $small: {
+      paddingBottom: 60,
+    },
   },
 }
 
@@ -128,20 +135,12 @@ export const filterModal = {
           },
         },
         labelButtons: {
-          main: {
-            $web: buttonsWrapper,
-          },
-          item: {
-            $web: labelButton,
-          },
+          main: buttonsWrapper,
+          item: labelButton,
         },
         stateButtons: {
-          main: {
-            $web: buttonsWrapper,
-          },
-          item: {
-            $web: stateButton,
-          },
+          main: buttonsWrapper,
+          item: stateButton,
         },
       },
       bottomSection: {

--- a/src/theme/components/modals/groupBookingModal.js
+++ b/src/theme/components/modals/groupBookingModal.js
@@ -4,9 +4,16 @@ import { defaultTextStyle } from './baseModal'
 export const groupBookingModal = {
   content: {
     main: {
-      $xsmall: {
-        width: '90%',
-        maxWidth: '800px',
+      $web: {
+        $xsmall: {
+          maxWidth: '800px',
+        },
+      },
+      $all: {
+        $xsmall: {
+          width: '90%',
+          maxWidth: 800,
+        },
       },
     },
     body: {

--- a/src/theme/components/modals/presenterDetailsModal.js
+++ b/src/theme/components/modals/presenterDetailsModal.js
@@ -12,9 +12,16 @@ export const presenterDetailsModal = {
   main: {},
   content: {
     main: {
-      $xsmall: {
-        width: '90%',
-        maxWidth: '800px',
+      $web: {
+        $xsmall: {
+          maxWidth: '800px',
+        },
+      },
+      $all: {
+        $xsmall: {
+          width: '90%',
+          maxWidth: 800,
+        },
       },
     },
     header: {
@@ -53,28 +60,48 @@ export const presenterDetailsModal = {
           },
         },
         title: {
-          $xsmall: {
-            fontFamily: 'Inter',
-            color: colors.lightGray,
-            marginBottom: '5px',
-            fontWeight: '500',
-            fontSize: 18,
+          $web: {
+            $xsmall: {
+              fontFamily: 'Inter',
+              marginBottom: '5px',
+            },
+            $small: {
+              lineHeight: '30px',
+            },
           },
-          $small: {
-            lineHeight: '30px',
-            fontSize: 25,
+          $all: {
+            $xsmall: {
+              color: colors.lightGray,
+              marginBottom: 5,
+              fontWeight: '500',
+              fontSize: 18,
+            },
+            $small: {
+              lineHeight: 30,
+              fontSize: 25,
+            },
           },
         },
         company: {
-          $xsmall: {
-            fontFamily: 'Inter',
-            fontWeight: '400',
-            lineHeight: '15px',
-            fontSize: 12,
+          $web: {
+            $xsmall: {
+              fontFamily: 'Inter',
+              lineHeight: '15px',
+            },
+            $small: {
+              lineHeight: '19px',
+            },
           },
-          $small: {
-            lineHeight: '19px',
-            fontSize: 16,
+          $all: {
+            $xsmall: {
+              fontWeight: '400',
+              lineHeight: 15,
+              fontSize: 12,
+            },
+            $small: {
+              lineHeight: 19,
+              fontSize: 16,
+            },
           },
         },
       },

--- a/src/theme/components/sessionLink.js
+++ b/src/theme/components/sessionLink.js
@@ -2,22 +2,22 @@ import { colors } from '../colors'
 
 export const sessionLink = {
   main: {
-    $web: {
-      $xsmall: {
-        marginTop: 5,
-        marginRight: 20,
-        flexWrap: 'wrap',
-      },
-      $small: {
-        marginTop: 29,
-        marginRight: 79,
-      },
+    $xsmall: {
+      marginTop: 5,
+      marginRight: 20,
+      flexWrap: 'wrap',
+    },
+    $small: {
+      marginTop: 29,
+      marginRight: 79,
     },
   },
   text: {
     $web: {
+      width: 'fit-content',
+    },
+    $all: {
       $xsmall: {
-        width: 'fit-content',
         color: colors.black,
         fontSize: 14,
         lineHeight: 17,
@@ -27,6 +27,10 @@ export const sessionLink = {
         fontSize: 16,
         lineHeight: 19,
       },
+    },
+    $native: {
+      flexDirection: 'row',
+      alignSelf: 'flex-start',
     },
   },
 }

--- a/src/theme/components/sessionLink.js
+++ b/src/theme/components/sessionLink.js
@@ -16,6 +16,10 @@ export const sessionLink = {
     $web: {
       width: 'fit-content',
     },
+    $native: {
+      flexDirection: 'row',
+      alignSelf: 'flex-start',
+    },
     $all: {
       $xsmall: {
         color: colors.black,
@@ -27,10 +31,6 @@ export const sessionLink = {
         fontSize: 16,
         lineHeight: 19,
       },
-    },
-    $native: {
-      flexDirection: 'row',
-      alignSelf: 'flex-start',
     },
   },
 }

--- a/src/theme/components/sessionTime.js
+++ b/src/theme/components/sessionTime.js
@@ -2,53 +2,41 @@ import { colors } from '../colors'
 
 export const sessionTime = {
   main: {
-    $web: {
-      $xsmall: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'flex-start',
-        padding: 0,
-        margin: 0,
-      },
-      $small: {
-        flex: 1,
-      },
+    $xsmall: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'flex-start',
+      padding: 0,
+      margin: 0,
+    },
+    $small: {
+      flex: 1,
     },
   },
   clockIcon: {
     main: {
       $xsmall: {
-        $web: {
-          display: 'none',
-          width: 19,
-          height: 20,
-        },
+        display: 'none',
+        width: 19,
+        height: 20,
       },
       $small: {
-        $web: {
-          display: 'flex',
-          marginRight: 5,
-        },
+        display: 'flex',
+        marginRight: 5,
       },
     },
   },
   timeText: {
     main: {
-      $web: {
-        flexBasis: 200,
-        width: 0,
-      },
+      flexBasis: 200,
+      width: 0,
     },
     content: {
       $xsmall: {
-        $web: {
-          color: colors.lightGray01,
-        },
+        color: colors.lightGray01,
       },
       $small: {
-        $web: {
-          color: colors.black,
-        },
+        color: colors.black,
       },
     },
   },

--- a/src/theme/components/sessions.js
+++ b/src/theme/components/sessions.js
@@ -4,6 +4,8 @@ export const sessions = {
     $web: {
       width: '100vw',
       flex: 1,
+      overflowX: 'hidden',
+      maxWidth: '100%',
     },
     $native: {
       flexDirection: 'column',

--- a/src/theme/components/sessions.js
+++ b/src/theme/components/sessions.js
@@ -81,7 +81,7 @@ export const sessions = {
                 },
                 $all: {
                   fontSize: 20,
-                  fontWeight: 500,
+                  fontWeight: '500',
                   textDecorationLine: 'underline',
                   color: colors.black,
                 },

--- a/src/theme/components/sessions.js
+++ b/src/theme/components/sessions.js
@@ -1,57 +1,87 @@
 import { colors } from '../colors'
 export const sessions = {
-  $web: {
-    main: {
+  main: {
+    $web: {
+      width: '100vw',
+      flex: 1,
+    },
+    $native: {
+      flexDirection: 'column',
+      width: '100%',
+    },
+    $all: {
       $xsmall: {
-        flex: 1,
         backgroundColor: colors.white01,
         padding: 20,
-        width: '100vw',
       },
       $small: {
         padding: 50,
       },
     },
-    content: {
-      header: {
-        main: {
+  },
+  content: {
+    header: {
+      main: {
+        $all: {
           width: '100%',
           marginVertical: 20,
           backgroundColor: colors.transparent,
           flexDirection: 'row',
           justifyContent: 'center',
         },
-        content: {
-          left: {
+        $native: {
+          height: 40,
+          marginTop: 0,
+          marginBottom: 20,
+        },
+      },
+      content: {
+        left: {
+          main: {
+            $web: {
+              maxWidth: '10%',
+            },
+            $native: {
+              display: 'none',
+            },
+          },
+        },
+        center: {
+          $native: {
             main: {
+              width: '100%',
+              alignItems: 'flex-start',
+              justifyContent: 'center',
+            },
+          },
+        },
+        right: {
+          main: {
+            $xsmall: {
               maxWidth: '10%',
             },
           },
-          center: {},
-          right: {
-            main: {
+          content: {
+            filterIcon: {
               $xsmall: {
-                maxWidth: '10%',
+                color: colors.black,
+                paddingRight: 5,
+              },
+              $small: {
+                paddingRight: 10,
               },
             },
-            content: {
-              filterIcon: {
-                $xsmall: {
-                  color: colors.black,
-                  paddingRight: 5,
-                },
-                $small: {
-                  paddingRight: 10,
-                },
+            filterButton: {
+              main: {
+                marginRight: 40,
               },
-              filterButton: {
-                main: {
-                  marginRight: 40,
+              content: {
+                $web: {
+                  letterSpacing: 0.1,
                 },
-                content: {
+                $all: {
                   fontSize: 20,
                   fontWeight: 500,
-                  letterSpacing: '0.1em',
                   textDecorationLine: 'underline',
                   color: colors.black,
                 },

--- a/src/theme/containers/gridContainer.js
+++ b/src/theme/containers/gridContainer.js
@@ -33,12 +33,16 @@ export const gridContainer = {
             },
             content: {
               text: {
-                color: colors.white,
-                fontFamily: 'Inter',
-                fontWeight: '600',
-                paddingLeft: 10,
-                fontSize: 20,
-                fontStyle: 'normal',
+                $web: {
+                  fontFamily: 'Inter',
+                },
+                $all: {
+                  color: colors.white,
+                  fontWeight: '600',
+                  paddingLeft: 10,
+                  fontSize: 20,
+                  fontStyle: 'normal',
+                },
               },
             },
           },

--- a/src/theme/dynamicClassMap.js
+++ b/src/theme/dynamicClassMap.js
@@ -5,7 +5,7 @@
 /****************** IMPORTANT ******************/
 
 import { setColors } from './colors'
-import { get } from '@keg-hub/jsutils'
+import { get, checkCall } from '@keg-hub/jsutils'
 import { setFonts } from './typography'
 import { styleSheetParser } from '@keg-hub/re-theme/styleParser'
 
@@ -13,7 +13,7 @@ import { styleSheetParser } from '@keg-hub/re-theme/styleParser'
  * Cache holder of the parsed ef-classes from the DOM stylesheets
  * @object
  */
-let __parsedEfClasses = { classList: {} }
+let __parsedEfClasses
 
 const efThemeClasses = [
   '.ef-sessions-background',
@@ -138,7 +138,8 @@ const classFormatter = (cssRule, rootSelector, formatted, cssToJs) => {
   const cssText = cssRule.cssText
 
   formatted.classList = formatted.classList || {}
-  formatted.classList[selectorRef] = cssToJs(
+  formatted.classList[selectorRef] = checkCall(
+    cssToJs,
     cssText,
     formatted.classList[selectorRef]
   )
@@ -168,12 +169,12 @@ export const parseCustomClasses = () => {
   setupColors(__parsedEfClasses)
   setupFonts(__parsedEfClasses)
 
-  return __parsedEfClasses
+  return __parsedEfClasses || { classList: {} }
 }
 
 /**
  * Automatically make call to parse the stylesheets on the dom
  */
 // Comment out for now untils Re-Theme gets updated with CssToJS changes
-// parseCustomClasses()
+parseCustomClasses()
 export const getParsedClasses = () => __parsedEfClasses

--- a/src/theme/dynamicClassMap.js
+++ b/src/theme/dynamicClassMap.js
@@ -69,27 +69,11 @@ const getBackgroundColor = (obj, classPath, fallback) => {
 const setupColors = parsed => {
   // Build the colors object
   const colors = {
-    default: get(parsed.classList, `ef-sessions-text-default.color`, 'inherit'),
-    color1: getBackgroundColor(
-      parsed.classList,
-      `ef-sessions-button-default`,
-      'inherit'
-    ),
-    color2: getBackgroundColor(
-      parsed.classList,
-      `ef-sessions-details-header`,
-      'inherit'
-    ),
-    color3: getBackgroundColor(
-      parsed.classList,
-      `ef-sessions-timeslot-header`,
-      'inherit'
-    ),
-    color4: getBackgroundColor(
-      parsed.classList,
-      `ef-sessions-button-primary`,
-      'inherit'
-    ),
+    default: get(parsed.classList, `ef-sessions-text-default.color`),
+    color1: getBackgroundColor(parsed.classList, `ef-sessions-button-default`),
+    color2: getBackgroundColor(parsed.classList, `ef-sessions-details-header`),
+    color3: getBackgroundColor(parsed.classList, `ef-sessions-timeslot-header`),
+    color4: getBackgroundColor(parsed.classList, `ef-sessions-button-primary`),
   }
 
   // Set the colors object, so when the theme gets imported, it has these available
@@ -114,11 +98,7 @@ const setupColors = parsed => {
  * @return {void}
  */
 const setupFonts = parsed => {
-  const headings = get(
-    parsed.classList,
-    `ef-sessions-name.fontFamily`,
-    'inherit'
-  )
+  const headings = get(parsed.classList, `ef-sessions-name.fontFamily`, '')
 
   setFonts(
     {

--- a/src/theme/dynamicClassMap.js
+++ b/src/theme/dynamicClassMap.js
@@ -175,6 +175,6 @@ export const parseCustomClasses = () => {
 /**
  * Automatically make call to parse the stylesheets on the dom
  */
-// Comment out for now untils Re-Theme gets updated with CssToJS changes
 parseCustomClasses()
-export const getParsedClasses = () => __parsedEfClasses
+
+export const getParsedClasses = () => parseCustomClasses()

--- a/tap.js
+++ b/tap.js
@@ -2,8 +2,8 @@
 
 
 const pathToEntryPoint = process.env.TEST_BUILD 
-  ? 'apps/BuildTest.js'
-  : 'apps/Main.js'
+  ? '../../apps/BuildTest.js'
+  : '../../apps/Main.js'
 
 module.exports = {
   name: 'events-force-x5',

--- a/tap.js
+++ b/tap.js
@@ -1,12 +1,16 @@
 
-
-const findPath = process.env.PLATFORM === 'web'
+/**
+ * It would be better to use the node core module `path`
+ * But this file is imported into the the app rootContainer, which is frontend
+ * So instead if finds the path to the tap root based on the Platform
+ */
+const tapRootPath = process.env.PLATFORM === 'web'
   ? '.'
   : '../..'
 
 const pathToEntryPoint = process.env.TEST_BUILD 
-  ? `${findPath}/apps/BuildTest.js`
-  : `${findPath}/apps/Main.js`
+  ? `${tapRootPath}/apps/BuildTest.js`
+  : `${tapRootPath}/apps/Main.js`
 
 module.exports = {
   name: 'events-force-x5',

--- a/tap.js
+++ b/tap.js
@@ -1,9 +1,12 @@
 
 
+const findPath = process.env.PLATFORM === 'web'
+  ? '.'
+  : '../..'
 
 const pathToEntryPoint = process.env.TEST_BUILD 
-  ? '../../apps/BuildTest.js'
-  : '../../apps/Main.js'
+  ? `${findPath}/apps/BuildTest.js`
+  : `${findPath}/apps/Main.js`
 
 module.exports = {
   name: 'events-force-x5',

--- a/tap.js
+++ b/tap.js
@@ -1,8 +1,9 @@
-const path = require('path')
+
+
 
 const pathToEntryPoint = process.env.TEST_BUILD 
-  ? path.join(__dirname, 'apps/BuildTest.js') 
-  : path.join(__dirname, 'apps/Main.js')
+  ? 'apps/BuildTest.js'
+  : 'apps/Main.js'
 
 module.exports = {
   name: 'events-force-x5',
@@ -23,6 +24,9 @@ module.exports = {
           Icons: 'assets/icons'
         },
         web: {
+          SVTapEntry: pathToEntryPoint
+        },
+        native: {
           SVTapEntry: pathToEntryPoint
         }
       }


### PR DESCRIPTION
**Ticket [ZEN-355](https://jira.simpleviewtools.com/browse/ZEN-355)** 

> **Notes**
> This PR is directly tied to [this PR](https://github.com/simpleviewinc/keg-hub/pull/38)
>   * They should be merged at the same time
>
> Originally this ticket was to add a `react-helmet`
>   * I could not get that library to not de-dupe styles that were already added
>   * I knew it had to be possible, so I wrote it myself
>
> Because of this, the jira ticket and this pull request don't really line up
>   * This should be the last styling change ticket. At least I hope it is
>   * I'm tired of dealing with it

### [Semver Status] major


## Context
* Events-Force is defining their styles in CSS
* Their clients can define custom CSS as well
* Currently, the tap, using re-theme, is only compatible with JSON style objects
* We need to be able to pull styles from stylesheets already applied to the DOM and apply them to keg-components

## Goal
* Use the already added className prop, to allow applying styles useing the dom
  * This should only happend when in a web context
  * Native context, the style attribute should still be used
  * Ensure no changes need to be added to taps when defining styles
  * Ensure styles are not duplicated on the Dom
    * This is gold right here. I can't find any other repo that does this
    * It puts ReTheme on another level in my opinion 
* Taps can now do the following
  * Use `.css` styles applied to the dom and classNames **(web only)**
  * Use the style attribute, and still get all the benefits of the Dom
    * This works cross-platform

## Updates
* `package.json`
  * Fixed issue with start command
* `src/assets/icons/evf/elements/dayToggleLeft.js` && `src/assets/icons/evf/elements/dayToggleRight.js`
  * Clean up a little bit
  * Added memo hook
* `src/components/dates/dayToggle.js`
  * Fixed some styling issues
    * Updated to use `styles` instead of `style`
* `src/components/dates/updateDayButton.js`
  * Cleaned up styles
* `src/components/sessions.js`
  * Added ScrollView from `Keg-Components`
* `src/containers/gridContainer.js`
  * Added `?` on style paths
* `src/containers/rootContainer.js`
  * Added direct import of `sessionsContainer`
    * Was causing issues with mobile
* `src/theme/components/button/*`
  * **Most of these changes are to fix styling on mobile**
* `src/theme/dynamicClassMap.js`
  * Cleaned up a number issues with style sheet parsing
  * Updated to work with changes made to `ReTheme`
* `./tap.js`
  * Building on mobile throws errors when using `const path = require('path')`
  * Updated to use relative paths based on the packager


## Testing

> **Notes**
> This is the same tests as [this PR](https://github.com/simpleviewinc/keg-hub/pull/38)
> So if you already did the tests for that one, they you have test this one

* Run Docker package => `keg evf pack run docker.pkg.github.com/simpleviewinc/keg-packages/tap:keg-mobile-build`
  * Ensure it runs
  * Open the inspector and check out the `Dom Tree`
    * Styles should no longer be applied to the elements with the style attribute
      * [All View / Text components should be using a class](http://snpy.in/MwwBpH)
      * [Some will still have styles ( Animated elements / Some primitives )](http://snpy.in/TuQOGY)
      * [Some will have buttons and styles for animations (buttons)](http://snpy.in/3d2mAV)
* Test Docker package => `keg evf pack run docker.pkg.github.com/simpleviewinc/keg-packages/tap:keg-mobile-build test`
  * Ensure all tests pass
