### PR TITLE
Keg sessions@0.2.0

### DIFF
--- a/configs/rollup.config.js
+++ b/configs/rollup.config.js
@@ -1,3 +1,4 @@
+import analyze from 'rollup-plugin-analyzer'
 import babel from '@rollup/plugin-babel'
 import json from '@rollup/plugin-json'
 import resolve from '@rollup/plugin-node-resolve'
@@ -17,6 +18,7 @@ const path = require('path')
 const tapPath = require('app-root-path').path
 const corePath = path.join(`${tapPath}`, `node_modules/keg-core`)
 const isProd = process.env.NODE_ENV === 'production'
+const { ANALYZE } = process.env
 
 const peerExternals = [ 'react', 'react-dom' ]
 const mainExternals = [
@@ -156,5 +158,6 @@ export default {
     cleanup(),
     isProd && terser(),
     bundleSize(),
+    ANALYZE && analyze()
   ],
 }

--- a/configs/rollup.config.js
+++ b/configs/rollup.config.js
@@ -11,10 +11,12 @@ import sourcemaps from 'rollup-plugin-sourcemaps'
 import bundleSize from 'rollup-plugin-bundle-size'
 import generatePackageJson from './plugins/generatePackageJson'
 import image from '@rollup/plugin-image'
+import { terser } from "rollup-plugin-terser"
 
 const path = require('path')
 const tapPath = require('app-root-path').path
 const corePath = path.join(`${tapPath}`, `node_modules/keg-core`)
+const isProd = process.env.NODE_ENV === 'production'
 
 const peerExternals = [ 'react', 'react-dom' ]
 const mainExternals = [
@@ -152,6 +154,7 @@ export default {
       },
     }),
     cleanup(),
+    isProd && terser(),
     bundleSize(),
   ],
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "format:prettier": "prettier --config ./configs/prettier.config.js --ignore-path .eslintignore --write '**/*.{js,jsx}'",
     "format": "yarn format:prettier && yarn format:eslint",
     "eslint:watch": "onchange '**/*.{js,jsx}' -- eslint --config ./configs/eslintrc.config.js {{changed}} --fix",
+    "analyze": "cd node_modules/keg-core; ANALYZE=true NODE_ENV=production KEG_COMPONENT_RESOLVER=true yarn roll:dev",
     "build": "cd node_modules/keg-core; NODE_ENV=production KEG_COMPONENT_RESOLVER=true yarn roll:dev",
     "dev": "nodemon --watch ./apps --watch ./src --exec yarn build"
   },
@@ -75,6 +76,7 @@
     "prettier": "2.0.5",
     "rimraf": "^3.0.1",
     "rollup": "^2.23.1",
+    "rollup-plugin-analyzer": "^3.3.0",
     "rollup-plugin-bundle-size": "^1.0.3",
     "rollup-plugin-cleanup": "^3.1.1",
     "rollup-plugin-clear": "^2.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keg-hub/tap-events-force",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Events Force Tap for the Keg",
   "main": "index.js",
   "author": "Lance Tipton <lancetipton04@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "css-to-react-native-transform": "1.9.0",
-    "keg-core": "npm:@keg-hub/keg-core@5.0.1"
+    "keg-core": "npm:@keg-hub/keg-core@6.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.10.3",
@@ -62,6 +62,7 @@
     "app-root-path": "3.0.0",
     "babel-eslint": "10.1.0",
     "babel-plugin-module-resolver": "4.0.0",
+    "date-fns": "2.16.1",
     "eslint": "7.1.0",
     "eslint-plugin-jest": "23.13.2",
     "eslint-plugin-react": "7.20.0",
@@ -69,7 +70,6 @@
     "husky": "4.2.5",
     "jest": "26.1.0",
     "lint-staged": "10.2.10",
-    "moment": "2.27.0",
     "nodemon": "2.0.4",
     "onchange": "7.0.2",
     "prettier": "2.0.5",
@@ -81,7 +81,8 @@
     "rollup-plugin-generate-package-json": "^3.2.0",
     "rollup-plugin-jsx": "^1.0.3",
     "rollup-plugin-nodent": "^0.2.2",
-    "rollup-plugin-sourcemaps": "^0.6.2"
+    "rollup-plugin-sourcemaps": "^0.6.2",
+    "rollup-plugin-terser": "^7.0.2"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keg-hub/tap-events-force",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Events Force Tap for the Keg",
   "main": "index.js",
   "author": "Lance Tipton <lancetipton04@gmail.com>",

--- a/src/components/button/evfButton.js
+++ b/src/components/button/evfButton.js
@@ -2,24 +2,31 @@ import React, { useMemo } from 'react'
 import { View, Button } from '@keg-hub/keg-components'
 import { useStylesCallback } from '@keg-hub/re-theme'
 import { useParsedStyle } from 'SVHooks/useParsedStyle'
+import { set, get } from '@keg-hub/jsutils'
 
 /**
- * @param {object} theme
- * @param {object} custom - contains {type, styles}
+ * Builds the styles for the Evf button merging the default styles with the parsed styles
+ * @param {Object} theme - Global Theme object
+ * @param {Object} custom - contains {type, styles, parsed}
+ * 
+ * @returns {Object} - Merged Evf button styles
  */
 const buildStyles = (theme, custom) => {
   const btnStyles = theme.get(`button.evfButton.${custom.type}`)
-  const parsedState = { main: custom.parsed }
+  // Get the keys of the content.button, to get a list of all button states
+  // This allows dynamically matching the Theme states even if they are changed
+  const stateKeys = Object.keys(get(btnStyles, 'content.button', {}))
 
-  return theme.get(btnStyles, custom.styles, {
-    content: {
-      button: {
-        active: parsedState,
-        default: parsedState,
-        hover: parsedState,
-      },
-    },
-  })
+  return theme.get(
+    btnStyles,
+    custom.styles,
+    custom.parsed && 
+      // Loop over the state keys, and set the parsed styles for each
+      stateKeys.reduce((parsed, state) => {
+        set(parsed, `content.button.${state}.main`, custom.parsed)
+        return parsed
+      }, {})
+  )
 }
 
 /**

--- a/src/components/dates/dayToggle.js
+++ b/src/components/dates/dayToggle.js
@@ -1,7 +1,7 @@
 import React from 'react'
-import moment from 'moment'
+import { format, parse } from 'date-fns'
 import { UpdateDayButton } from './updateDayButton'
-import { useTheme } from '@keg-hub/re-theme'
+import { useTheme, useDimensions } from '@keg-hub/re-theme'
 import { noOp } from 'SVUtils/helpers/method/noop'
 import { View, Text } from '@keg-hub/keg-components'
 import { isMobileSize } from 'SVUtils/theme'
@@ -11,9 +11,11 @@ import { isMobileSize } from 'SVUtils/theme'
  * @param {string} currentDate - current date string
  * @param {boolean} isMobileSize
  */
-const getDayString = (currentDate, isMobileSize) => {
-  const format = isMobileSize ? 'dddd' : 'D MMMM YYYY'
-  return currentDate ? moment(currentDate).format(format) : 'N/A'
+const getDayString = (currentDate, isMobileSize, width) => {
+  const parsedDate = parse(currentDate, `yyyy-MM-dd`, new Date())
+  const dateFormat = isMobileSize ? 'd MMM' : width < 750 ? 'd MMM yyyy'  : 'd MMMM yyyy'
+
+  return currentDate ? format(parsedDate, dateFormat) : 'N/A'
 }
 
 /**
@@ -38,8 +40,10 @@ export const DayToggle = props => {
 
   const theme = useTheme()
   const dayToggleStyles = theme.get('dayToggle')
-  const dayText = `Day ${dayNumber} 
-    - ${getDayString(date, isMobileSize(theme))}`
+
+  const dims = useDimensions()
+  const dayText = `Day ${dayNumber} - ${getDayString(date, isMobileSize(theme), dims.width)}`
+
   return (
     <View
       className={'ef-sessions-date-selector'}

--- a/src/components/modals/presenterDetails.js
+++ b/src/components/modals/presenterDetails.js
@@ -3,7 +3,7 @@ import { Image, View, Text } from '@keg-hub/keg-components'
 import { ScrollView } from 'react-native'
 import { useTheme, useDimensions } from '@keg-hub/re-theme'
 import { BaseModal, contentDefaultMaxHeight } from './baseModal'
-import placeholderImage from 'SVAssets/profile_placeholder.png'
+const placeholderImage = `https://raw.githubusercontent.com/simpleviewinc/tap-events-force/master/src/assets/profile_placeholder.png`
 
 /**
  * PresenterDetailModal

--- a/src/hooks/useParsedStyle.js
+++ b/src/hooks/useParsedStyle.js
@@ -1,9 +1,17 @@
 import { useMemo } from 'react'
+import { isObj } from '@keg-hub/jsutils'
 import { getParsedClasses } from '../theme/dynamicClassMap'
 
+/**
+ * Gets the parsed cssInJs styles from the dynamicClassMap parsing
+ * @function
+ * @param {string} className - Name of the class who's styles should be returned
+ * 
+ * @returns {Object} - Parsed styles for the passed in className
+ */
 export const useParsedStyle = className => {
   return useMemo(() => {
     const { classList } = getParsedClasses()
-    return classList[className]
+    return isObj(classList) && classList[className]
   }, [className])
 }

--- a/src/theme/components/dates/dayToggle.js
+++ b/src/theme/components/dates/dayToggle.js
@@ -8,9 +8,6 @@ export const dayToggle = {
         alignItems: 'center',
         justifyContent: 'space-between',
       },
-      $small: {
-        width: 300,
-      },
     },
     $native: {
       $xsmall: {
@@ -45,8 +42,7 @@ export const dayToggle = {
           fontFamily: 'Inter',
           fontSize: '18px',
           letterSpacing: '0.1em',
-          marginLeft: 10,
-          marginRight: 16,
+          mH: 16,
         },
         $small: {
           fontSize: '20px',

--- a/src/theme/components/sessions.js
+++ b/src/theme/components/sessions.js
@@ -75,7 +75,10 @@ export const sessions = {
             },
             filterButton: {
               main: {
-                marginRight: 40,
+                pos: 'absolute',
+                rt: 40,
+                pV: 8,
+                pH: 12,
               },
               content: {
                 $web: {

--- a/src/theme/dynamicClassMap.js
+++ b/src/theme/dynamicClassMap.js
@@ -1,9 +1,3 @@
-/****************** IMPORTANT ******************/ /*
- * This is a work in progress
- * It's NOT complete or expected to be working
- * This will be removed once it's complete
-/****************** IMPORTANT ******************/
-
 import { setColors } from './colors'
 import { get, checkCall } from '@keg-hub/jsutils'
 import { setFonts } from './typography'
@@ -15,6 +9,16 @@ import { styleSheetParser } from '@keg-hub/re-theme/styleParser'
  */
 let __parsedEfClasses
 
+/**
+ * Default empty classList when no events-force classes can be found
+ * @object
+ */
+const defEmptyClassList = { classList: {} }
+
+/**
+ * Classes defined by events-force to pull dynamic styles from
+ * @array
+ */
 const efThemeClasses = [
   '.ef-sessions-background',
   '.ef-button-default',
@@ -113,6 +117,13 @@ const setupFonts = parsed => {
   )
 }
 
+/**
+ * Passed as the callback for found matching classes
+ * Converts the class styles into a JS object so it can be added to the theme
+ * @function
+ *
+ * @return {Object} - Stylesheet styles from a matching class as an object
+ */
 const classFormatter = (cssRule, rootSelector, formatted, cssToJs) => {
   const selectorRef = rootSelector.substring(1)
   const cssText = cssRule.cssText
@@ -146,10 +157,13 @@ export const parseCustomClasses = () => {
       classNames: efThemeClasses,
     })
 
+  if(!__parsedEfClasses || !__parsedEfClasses.classList)
+    return defEmptyClassList
+
   setupColors(__parsedEfClasses)
   setupFonts(__parsedEfClasses)
 
-  return __parsedEfClasses || { classList: {} }
+  return __parsedEfClasses
 }
 
 /**
@@ -157,4 +171,10 @@ export const parseCustomClasses = () => {
  */
 parseCustomClasses()
 
+/**
+ * Gets the cached Ef Class data or calls function to parse the Stylesheets
+ * @function
+ * 
+ * @returns {Object} __parsedEfClasses - Parsed styleSheet classes ad a JS Object
+ */
 export const getParsedClasses = () => parseCustomClasses()

--- a/src/utils/dateTime/getTimeFromDate.js
+++ b/src/utils/dateTime/getTimeFromDate.js
@@ -1,4 +1,4 @@
-import moment from 'moment'
+import { format } from 'date-fns'
 
 /**
  * Formats the given date to hh:mm format
@@ -6,5 +6,6 @@ import moment from 'moment'
  * @param {boolean} military - whether to format in 24 hr or not
  * @returns {string}
  */
-export const getTimeFromDate = (date, military = true) =>
-  moment(date).format(military ? 'HH:mm' : 'h:mma')
+export const getTimeFromDate = (date, military = true) => {
+  return format(new Date(date), military ? 'HH:mm' : 'h:mma')
+}

--- a/src/utils/models/sessions/buildHourSessionsMap.js
+++ b/src/utils/models/sessions/buildHourSessionsMap.js
@@ -1,4 +1,4 @@
-import moment from 'moment'
+import { getTimeFromDate } from '../../dateTime/getTimeFromDate'
 import { sortSessions } from './sortSessions'
 import { reduceObj } from '@keg-hub/jsutils'
 
@@ -16,7 +16,7 @@ export const buildHourSessionsMap = (sessions, dayNumber, asc) => {
   const sessionsMapping = sessions.reduce((mapped, session) => {
     if (session.dayNumber !== dayNumber) return mapped
 
-    const timeStr = moment(session.startDateTimeLocal).format('HH:mm')
+    const timeStr = getTimeFromDate(session.startDateTimeLocal)
     // create an array or append to existing list
     mapped[timeStr] = (mapped[timeStr] || []).concat(session)
 


### PR DESCRIPTION
## Context
* The keg-sessions bundle is larger then it needs to be
* There's a number of things we can do to improve the bundle size

## Goal
* Improve the keg-sessions packages by reducing the bundle size
  * I got bundle size down to around 214kb - This is more then 2x smaller then it was before

## Updates
* `.gitignore`
  * Ignores the fonts folder
    * At some point I'm going to update how the fonts are loaded. For local development I want to store the fonts
    * This way we don't have to keep calling google for them
* `configs/rollup.config.js`
  * Added `terser` and `analyze` roll-up plugin
    * terser - Minifies the build. Cuts out about 200kb
    * analyze - Give an overview of what's included in the bundle by size
* `package.json`
  * Updated the version to be `0.2.0`
    * There should be no breaking changes
    * All should be backwards compatible
  * Updated keg-core version to `6.0.0`
  * Removed `moment.js`
    * This is a huge package that was adding extra bloat to the bundle size
    * I replaced it with `date-fns.js`
* `src/components/button/evfButton.js`
  * Cleaned up how the dynamic styles are applied to buttons
  * Was causing issues when no stylesheet exists on the Dom
* `src/components/dates/dayToggle.js` && `src/utils/dateTime/getTimeFromDate.js`
  * Updated date parsing to use `date-fns.js` instead of `moment.js`
  * Fixed `...` issue when the Month name is too long
* `src/components/modals/presenterDetails.js`
  * Updated placeholder image to use a url instead of being converted to a data:base64 string
  * This reduced the bundle size significantly
* `src/hooks/useParsedStyle.js`
  * Fixed bug with classList throwing an error when it didn't exist
* `src/theme/components/dates/dayToggle.js`
  * Fixed an issue with styling the day toggle arrows
* `src/theme/components/sessions.js`
  * Updated how the filter button styles defined the location
  * This makes it much more consistent
* `src/theme/dynamicClassMap.js`
  * Cleaned up to always return a default classList object
  * Added condition to only update the fonts and colors when parse styles are returned
* `src/utils/models/sessions/buildHourSessionsMap.js`
  * The date code here was doing the same thing as the `getTimeFromDate` helper method
  * So I updated it to call that method instead of duplicating the code

## Testing

**Consumer**
* Run the consumer: `keg consumer pack run docker.pkg.github.com/simpleviewinc/keg-packages/keg-test-consumer:reducer-sessions-bundle-size`
  * This includes a bundle of all the changes from this pull request
* Navigate to http://local.kegdev.xyz
  * Ensure everything renders as expected
  * Change the browser window size
    * Ensure the filter button location is consistent
    * Ensure the filter button never overlaps the day toggle component
    * Ensure the day toggle component never switches to `...`
    * At a width of `750` the Month should switch to a `3 character version`
* Click the toggle modal demo button
  * Click the second presenter button
  * Ensure the placeholder image still loads

**Tap-Eventsforce**
* Run the tap: `keg evf pack run docker.pkg.github.com/simpleviewinc/keg-packages/tap:keg-sessions-0.2.0`
  * Do all the same tests from the consumer for the tap
  * Ensure it all renders properly
