### PR TITLE
fixed date parsing for safari

### DIFF
--- a/src/utils/dateTime/getTimeFromDate.js
+++ b/src/utils/dateTime/getTimeFromDate.js
@@ -7,7 +7,7 @@ import { format } from 'date-fns'
  * @returns {string}
  */
 export const getTimeFromDate = (date, military = true) => {
-  let parsed = Date.parse(new Date(date.replace(/-/g, '/')))
+  let parsed = Date.parse(date)
   if (isNaN(parsed)) parsed = new Date(date.replace(/-/g, '/'))
   return format(parsed, military ? 'HH:mm' : 'h:mma')
 }

--- a/src/utils/dateTime/getTimeFromDate.js
+++ b/src/utils/dateTime/getTimeFromDate.js
@@ -2,10 +2,12 @@ import { format } from 'date-fns'
 
 /**
  * Formats the given date to hh:mm format
- * @param {Date} date - some date ex: 2020-08-03 13:00:00. if null, it will take local date/time
+ * @param {string|Date} date - some date ex: 2020-08-03 13:00:00. if null, it will take local date/time
  * @param {boolean} military - whether to format in 24 hr or not
  * @returns {string}
  */
 export const getTimeFromDate = (date, military = true) => {
-  return format(new Date(date), military ? 'HH:mm' : 'h:mma')
+  let parsed = Date.parse(new Date(date.replace(/-/g, '/')))
+  if (isNaN(parsed)) parsed = new Date(date.replace(/-/g, '/'))
+  return format(parsed, military ? 'HH:mm' : 'h:mma')
 }


### PR DESCRIPTION
**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-386)

## Context

* With the latest update on `getTimeFromDate` to use the built in `Date` constructor. It introduced a bug on safari where it does not properly create a `Date` object if the formatting is "incorrect"
* we're passing in a string to this helper function and it is formatted like: `2020-08-03 13:00:00`
   * safari does not support parsing the dashes `-`. but it does support `/`
   * so just replace the dashes with slashes if the parsing fails
## Goal

* Update `getTimeFromDate` to format the date to an acceptable format for browser that complains about it

## Updates

* `src/utils/dateTime/getTimeFromDate.js`
   * parse the date string for safari / any other browser that doesn't support `-`

## Testing

* run `keg dpg run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:safari-date-parse-bug`
* run the app on safari > verify that it doesn't throw an error/crash
* run on the other browsers to make sure it still works the same/doesn't crash
