### PR TITLE
Sort agendaSessions by timeblock

### DIFF
--- a/src/actions/session/mapSessionInterface.js
+++ b/src/actions/session/mapSessionInterface.js
@@ -33,9 +33,9 @@ const mapAgendaSessions = (sessions, agendaDays) => {
   if (!sessions || !agendaDays) return
 
   // object will look something like:
-  // {
-  //   1: {9:00: [session1, session2], 10:00: []} //day 1
-  //   2: {9:15: [session]}, //day 2
+  // { ordered by timeblock
+  //   1: [{timeBlock: '9:00', sessions: [session1, session2]}] //day 1
+  //   2: [{timeBlock: '13:00', sessions: [session1]}, {timeBlock: '15:00', sessions: [session1]}], //day 2
   // }
   const agendaSessions = agendaDays.reduce((map, nextDay) => {
     map[nextDay.dayNumber] = buildHourSessionsMap(sessions, nextDay.dayNumber)

--- a/src/components/sessions.js
+++ b/src/components/sessions.js
@@ -10,7 +10,7 @@ import { useAgenda } from 'SVHooks/models/useAgenda'
 import { useParsedStyle } from 'SVHooks/useParsedStyle'
 import { DayToggle } from 'SVComponents/dates/dayToggle'
 import { noOp } from 'SVUtils/helpers/method/noop'
-import { pickKeys, mapObj, get } from '@keg-hub/jsutils'
+import { pickKeys, get } from '@keg-hub/jsutils'
 import { EVFIcons } from 'SVIcons'
 import { Values } from 'SVConstants'
 import { useKegEvent } from 'SVHooks/events'
@@ -99,7 +99,7 @@ const SessionsHeader = ({ styles, onDayChange, labels }) => {
  * Sets up the container for a group of sessions on a specific day
  * @param {object} props
  * @param {Array<import('SVModels/label').Label>} props.labels - session labels
- * @param {object} props.daySessions - group of sessions in the form of {'9:15': [sessionA, sessionB,..]}
+ * @param {Array} props.daySessions - group of sessions by block. see buildHourSessionsMap helper
  * @param {boolean} props.enableFreeLabel - whether to display 'FREE' on session with no pricing or not
  * @returns {Component}
  */
@@ -109,14 +109,14 @@ const AgendaSessions = React.memo(
 
     return (
       <ScrollView>
-        { mapObj(daySessions, (timeBlock, sessions) => {
+        { daySessions.map(daySession => {
           return (
             // creates a gridContainer separated by hour blocks
             <GridContainer
-              key={timeBlock}
-              sessions={sessions}
+              key={daySession?.timeBlock}
+              sessions={daySession?.sessions}
               labels={labels}
-              timeBlock={timeBlock}
+              timeBlock={daySession?.timeBlock}
               enableFreeLabel={enableFreeLabel}
             />
           )

--- a/src/utils/models/sessions/__tests__/buildHourSessionsMap.js
+++ b/src/utils/models/sessions/__tests__/buildHourSessionsMap.js
@@ -5,8 +5,11 @@ import { mapObj } from '@keg-hub/jsutils'
 describe('buildHourSessionsMap', () => {
   it('should filter on day 1', () => {
     const map = buildHourSessionsMap(testData.sessions, 1)
-    expect(map['09:00'].length).toEqual(1)
-    expect(map['13:00'].length).toEqual(1)
+    expect(map[0].timeBlock).toEqual('09:00')
+    expect(map[0].sessions.length).toEqual(1)
+
+    expect(map[1].timeBlock).toEqual('13:00')
+    expect(map[1].sessions.length).toEqual(1)
   })
 
   it('should return the map with empty array for values', () => {

--- a/src/utils/models/sessions/buildHourSessionsMap.js
+++ b/src/utils/models/sessions/buildHourSessionsMap.js
@@ -1,31 +1,41 @@
 import { getTimeFromDate } from '../../dateTime/getTimeFromDate'
 import { sortSessions } from './sortSessions'
-import { reduceObj } from '@keg-hub/jsutils'
 
 /**
  * Filters the sessions given a day number
  * @param {Array<import('SVModels/session').Session>} sessions
  * @param {number} dayNumber
  * @param {boolean=} asc - order ascending by name
- * @returns {object} - where key is the hour, value is the array of sessions
- *                   - ex: {6:[], 7:[sessionA, sessionB, etc], 8:[sessionC, etc]}
+ * @returns {Array} - array of objects containing timeblock and sessions:
+ *                    ex: [{timeBlock: '9:00', sessions: [session1, session2]}]
  */
 export const buildHourSessionsMap = (sessions, dayNumber, asc) => {
-  // Filter out the sessions not matching the day
-  // Group them by hour
-  const sessionsMapping = sessions.reduce((mapped, session) => {
-    if (session.dayNumber !== dayNumber) return mapped
+  // 1. Filter out the sessions not matching the day
+  // 2. Group the sessions by start block
+  // 3. sort the array by the start block
+  return sessions
+    .reduce((items, session) => {
+      if (session.dayNumber !== dayNumber) return items
 
-    const timeStr = getTimeFromDate(session.startDateTimeLocal)
-    // create an array or append to existing list
-    mapped[timeStr] = (mapped[timeStr] || []).concat(session)
+      const timeBlock = getTimeFromDate(session.startDateTimeLocal)
 
-    return mapped
-  }, {})
+      // check the session start time
+      const mapIndex = items.findIndex(item => timeBlock === item.timeBlock)
 
-  // Sort the mapped sessiosn based on their value
-  return reduceObj(sessionsMapping, (key, val, mapping) => {
-    mapping[key] = sortSessions(val, asc)
-    return mapping
-  })
+      // if the time block already exists in the mapping array, append the session
+      // otherwise push a new object to it
+      mapIndex >= 0
+        ? (items[mapIndex].sessions = sortSessions(
+            (items[mapIndex].sessions || []).concat(session),
+            asc
+          ))
+        : items.push({ timeBlock, sessions: [session] })
+
+      return items
+    }, [])
+    .sort(
+      (itemA, itemB) =>
+        new Date(`1970/01/01 ${itemA.timeBlock}`) -
+        new Date(`1970/01/01 ${itemB.timeBlock}`)
+    )
 }


### PR DESCRIPTION


**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-390)

## Context

* I noticed that our agenda sessions grid isn't actually sorting the sessions by time block. it just so happens that the test data we've been using is in the correct order


## Goal

* have the `AGENDA_SESSIONS` store actually be sorted by timeblock

## Updates

- updated unit test for buildHourSessionsMap
- updated buildHrSessionsMap to return an array instead of an object so we can sort it by time block

## Testing

* run `keg dpg run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:sort-by-hour-block`
* navigate to http://local.kegdev.xyz/
* switch to Day 1
* modify the JSON data to add a new session on day 1, and set the start time > 9 am  && < 1 pm
   * something like this
      ![image](https://user-images.githubusercontent.com/3317835/94873870-3ece7f00-0405-11eb-80ea-a51bcf5999f8.png)

* hit apply
* verify that the new session block gets added in between `9:00` block and `13:00`

### unit test
* run `keg dpg run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:sort-by-hour-block command=test`

