### PR TITLE
Zen 389 portal for web modals

### DIFF
--- a/src/components/hocs/tapIndex.js
+++ b/src/components/hocs/tapIndex.js
@@ -1,1 +1,2 @@
 export * from './withAppHeader'
+export * from './withPortal'

--- a/src/components/hocs/withPortal.js
+++ b/src/components/hocs/withPortal.js
@@ -1,0 +1,11 @@
+import { isNative } from 'SVUtils/platform'
+import ReactDOM from 'react-dom'
+
+/**
+ * Renders the component at a specific location in the DOM tree
+ * @param {Component} Component - component to render
+ * @param {Element} containerEl - DOM element to render to
+ */
+export const withPortal = (Component, containerEl) => {
+  return !isNative() ? ReactDOM.createPortal(Component, containerEl) : Component
+}

--- a/src/components/modals/baseModal.js
+++ b/src/components/modals/baseModal.js
@@ -4,6 +4,7 @@ import { useTheme, useDimensions } from '@keg-hub/re-theme'
 import { removeModal } from 'SVActions'
 import PropTypes from 'prop-types'
 import { EVFIcons } from 'SVIcons'
+import { withPortal } from 'SVComponents/hocs/tapIndex'
 
 /**
  * Title bar for modal
@@ -100,7 +101,7 @@ export const BaseModal = props => {
     }
   }, [ dismissed, onDismiss, removeModal ])
 
-  return (
+  return withPortal(
     <Modal
       className={className}
       styles={{ content: { ...baseStyles.content.main, maxHeight } }}
@@ -116,7 +117,8 @@ export const BaseModal = props => {
       />
 
       { children }
-    </Modal>
+    </Modal>,
+    document.body
   )
 }
 


### PR DESCRIPTION
**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-389)

## Context

* currently, we set the zIndex of the BaseModal to a high value so that it appears above other elements on the dom
* however, if a parent component has defined overflow: hidden or a z-index style, the modal may still appear below the parent on the z-axis.
* this is only relevant on web
* we need BaseModal to always break through
* you can see that the modal is appearing below the nav bar
     * ![image](https://user-images.githubusercontent.com/3317835/94968989-c2947400-04b6-11eb-89c5-6457b90b6170.png)



## Goal

* Utilize ReactDOM.createPortal to render the modals in the body element (ref)[https://reactjs.org/docs/portals.html]
* It will render to the `body` element by default until Evf lets me know of a different location. We can update it then

## Updates

* `src/components/hocs/withPortal.js`
   * on web, renders the component in a specific location on the DOM tree
   * on native, just renders it as is

* `src/components/modals/baseModal.js`
   * updated to use `withPortal` as this will affect all modals

## Testing

* Run `keg dpg run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:zen-389-portal`
* navigate to http://local.kegdev.xyz/test
* open the Inspector element
* open the `Presenter 3` modal (this modal has the most content)
* see that the modal element gets added within the `Body` element
    * ![portal](https://user-images.githubusercontent.com/3317835/94969405-831a5780-04b7-11eb-900d-18b95d6c9b2d.gif)

* Update your screen size so the modal reaches the navigation Bar
* verify that the modal appears over the nav bar now
