### PR TITLE
Zen 374 modal filter clear btn

### DIFF
--- a/src/components/modals/filter.js
+++ b/src/components/modals/filter.js
@@ -1,7 +1,7 @@
 import React, { useRef, useMemo, useCallback } from 'react'
 import { useTheme } from '@keg-hub/re-theme'
 import { BaseModal } from './baseModal'
-import { View, Text, ScrollView } from '@keg-hub/keg-components'
+import { View, Text, ScrollView, Button } from '@keg-hub/keg-components'
 import { EvfButton } from 'SVComponents/button/evfButton'
 import { sortLabels } from 'SVUtils'
 import { LabelButton } from 'SVComponents/labels/labelButton'
@@ -19,6 +19,7 @@ import {
   updateSelectedFilters,
   applySessionFilters,
   cancelSelectedFilters,
+  clearSelectedFilters,
 } from 'SVActions/session/filters'
 
 const { SESSION_BOOKING_STATES } = Values
@@ -217,9 +218,15 @@ const MiddleSection = ({ styles, labels }) => {
 const BottomSection = ({ styles, onButtonPress }) => {
   return (
     <View style={styles?.main}>
+      <Button
+        themePath='button.text.default'
+        styles={styles?.clearButton}
+        onClick={clearSelectedFilters}
+        content={'Clear Filters'}
+      />
       <EvfButton
         type={'primary'}
-        styles={styles?.button}
+        styles={styles?.applyButton}
         onClick={onButtonPress}
         text={'APPLY'}
       />

--- a/src/components/modals/filter.js
+++ b/src/components/modals/filter.js
@@ -13,6 +13,7 @@ import {
   pickKeys,
   checkCall,
   filterObj,
+  noPropArr,
 } from '@keg-hub/jsutils'
 import { useSelector, shallowEqual } from 'react-redux'
 import {
@@ -21,7 +22,6 @@ import {
   cancelSelectedFilters,
   clearSelectedFilters,
 } from 'SVActions/session/filters'
-import { noPropArr } from 'SVUtils/helpers/method/noop'
 
 const { SESSION_BOOKING_STATES } = Values
 

--- a/src/components/modals/filter.js
+++ b/src/components/modals/filter.js
@@ -21,6 +21,7 @@ import {
   cancelSelectedFilters,
   clearSelectedFilters,
 } from 'SVActions/session/filters'
+import { noPropArr } from 'SVUtils/helpers/method/noop'
 
 const { SESSION_BOOKING_STATES } = Values
 
@@ -79,7 +80,7 @@ const Content = ({ styles, onButtonPress, labels }) => {
       <BottomSection
         styles={styles?.bottomSection}
         onButtonPress={onButtonPress}
-        hasSelectedFilters={filters?.selectedFilters?.length > 0}
+        hasSelectedFilters={Boolean(filters?.selectedFilters?.length)}
       />
     </View>
   )
@@ -129,7 +130,7 @@ const useLabelOn = (selectedCount, selectedFilters, label) => {
  * @param {Array.<import('SVModels/label').Label>} props.labels - array of label items
  * @param {Array.<import('SVModels/label').Label>} props.selectedFilters - current selected filters
  */
-const LabelButtons = ({ styles, labels, selectedFilters = [] }) => {
+const LabelButtons = ({ styles, labels, selectedFilters = noPropArr }) => {
   /**
    * expected behavior:
    *   - all filters are 'toggled on' by default when no filter is selected

--- a/src/components/modals/filter.js
+++ b/src/components/modals/filter.js
@@ -64,16 +64,22 @@ export const Filter = ({ visible, labels }) => {
  * @param {Array<import('SVModels/label').Label>} props.labels
  */
 const Content = ({ styles, onButtonPress, labels }) => {
+  const { filters } = useSelector(
+    ({ items }) => pickKeys(items, ['filters']),
+    shallowEqual
+  )
   return (
     <View style={styles?.main}>
       <TopSection styles={styles?.topSection} />
       <MiddleSection
         labels={labels}
         styles={styles?.middleSection}
+        selectedFilters={filters?.selectedFilters}
       />
       <BottomSection
         styles={styles?.bottomSection}
         onButtonPress={onButtonPress}
+        hasSelectedFilters={filters?.selectedFilters?.length > 0}
       />
     </View>
   )
@@ -121,23 +127,19 @@ const useLabelOn = (selectedCount, selectedFilters, label) => {
  * @param {object} props
  * @param {object} props.styles - styles to be applied to LabelButton
  * @param {Array.<import('SVModels/label').Label>} props.labels - array of label items
+ * @param {Array.<import('SVModels/label').Label>} props.selectedFilters - current selected filters
  */
-const LabelButtons = ({ styles, labels }) => {
+const LabelButtons = ({ styles, labels, selectedFilters = [] }) => {
   /**
    * expected behavior:
    *   - all filters are 'toggled on' by default when no filter is selected
    *   - once a filter item is selected, the rest should be toggled off except for the selected item(s)
    */
-  const { filters } = useSelector(
-    ({ items }) => pickKeys(items, ['filters']),
-    shallowEqual
-  )
-
-  const selectedCount = filters.selectedFilters.length
+  const selectedCount = selectedFilters.length
   const isFilterEmpty = !selectedCount
 
   return labels.map(label => {
-    const isLabelOn = useLabelOn(selectedCount, filters.selectedFilters, label)
+    const isLabelOn = useLabelOn(selectedCount, selectedFilters, label)
     return (
       <LabelButton
         key={label.name}
@@ -181,8 +183,9 @@ const filteredBookingStates = filterObj(
  * @param {object} props
  * @param {object} props.styles - default from modal.filter.body.middleSection
  * @param {Array.<import('SVModels/label').Label>} props.labels - array of label items
+ * @param {Array.<import('SVModels/label').Label>} props.selectedFilters - current selected filters
  */
-const MiddleSection = ({ styles, labels }) => {
+const MiddleSection = ({ styles, labels, selectedFilters }) => {
   const stateLabels = useMemo(() => createStateLabels(filteredBookingStates), [
     filteredBookingStates,
   ])
@@ -196,6 +199,7 @@ const MiddleSection = ({ styles, labels }) => {
         <LabelButtons
           styles={styles.labelButtons?.item}
           labels={labels}
+          selectedFilters={selectedFilters}
         />
       </View>
 
@@ -203,6 +207,7 @@ const MiddleSection = ({ styles, labels }) => {
         <LabelButtons
           styles={styles?.stateButtons?.item}
           labels={stateLabels}
+          selectedFilters={selectedFilters}
         />
       </View>
     </ScrollView>
@@ -214,16 +219,19 @@ const MiddleSection = ({ styles, labels }) => {
  * @param {object} props
  * @param {object} props.styles - default from modal.filter.body.bottomSection theme
  * @param {Function} props.onButtonPress
+ * @param {boolean} props.hasSelectedFilters - whether or not the selectedFilters state is empty
  */
-const BottomSection = ({ styles, onButtonPress }) => {
+const BottomSection = ({ styles, onButtonPress, hasSelectedFilters }) => {
   return (
     <View style={styles?.main}>
-      <Button
-        themePath='button.text.default'
-        styles={styles?.clearButton}
-        onClick={clearSelectedFilters}
-        content={'Clear Filters'}
-      />
+      { hasSelectedFilters && (
+        <Button
+          themePath='button.text.default'
+          styles={styles?.clearButton}
+          onClick={clearSelectedFilters}
+          content={'Clear Filters'}
+        />
+      ) }
       <EvfButton
         type={'primary'}
         styles={styles?.applyButton}

--- a/src/components/modals/filter.js
+++ b/src/components/modals/filter.js
@@ -229,7 +229,7 @@ const BottomSection = ({ styles, onButtonPress, hasSelectedFilters }) => {
           themePath='button.text.default'
           styles={styles?.clearButton}
           onClick={clearSelectedFilters}
-          content={'Clear Filters'}
+          content={'clear filters'}
         />
       ) }
       <EvfButton

--- a/src/theme/components/modals/filterModal.js
+++ b/src/theme/components/modals/filterModal.js
@@ -145,11 +145,32 @@ export const filterModal = {
       },
       bottomSection: {
         main: {
-          alignItems: 'flex-end',
+          flD: 'row',
+          alS: 'flex-end',
+          fl: 1,
+          flWr: 'wrap',
         },
-        button: {
+        applyButton: {
           main: {
             minHeight: 45,
+          },
+        },
+        clearButton: {
+          main: {
+            pB: 5,
+            pH: 10,
+            jtC: 'flex-end',
+          },
+          content: {
+            $web: {
+              ltrS: 0.1,
+            },
+            $all: {
+              ftSz: 18,
+              ftWt: '500',
+              txDc: 'underline',
+              color: colors.lightGray01,
+            },
           },
         },
       },

--- a/src/theme/components/modals/filterModal.js
+++ b/src/theme/components/modals/filterModal.js
@@ -93,25 +93,22 @@ const buttonsWrapper = {
   },
 }
 
-const clearButtonDefault = (transparent = false) => ({
+const clearButtonDefault = {
   main: {
-    pB: 5,
-    pH: 15,
     jtC: 'flex-end',
-    bgC: transparent ? colors.transparent : undefined,
   },
   content: {
     $web: {
       ltrS: 0.1,
     },
     $all: {
-      ftSz: 18,
+      ftSz: 16,
       ftWt: '500',
       txDc: 'underline',
       color: colors.lightGray01,
     },
   },
-})
+}
 export const filterModal = {
   content: {
     main: {},
@@ -172,13 +169,10 @@ export const filterModal = {
         applyButton: {
           main: {
             minHeight: 45,
+            mL: 15
           },
         },
-        clearButton: {
-          default: clearButtonDefault(),
-          active: clearButtonDefault(true),
-          hover: clearButtonDefault(true),
-        },
+        clearButton: clearButtonDefault,
       },
     },
   },

--- a/src/theme/components/modals/filterModal.js
+++ b/src/theme/components/modals/filterModal.js
@@ -93,6 +93,25 @@ const buttonsWrapper = {
   },
 }
 
+const clearButtonDefault = (transparent = false) => ({
+  main: {
+    pB: 5,
+    pH: 15,
+    jtC: 'flex-end',
+    bgC: transparent ? colors.transparent : undefined,
+  },
+  content: {
+    $web: {
+      ltrS: 0.1,
+    },
+    $all: {
+      ftSz: 18,
+      ftWt: '500',
+      txDc: 'underline',
+      color: colors.lightGray01,
+    },
+  },
+})
 export const filterModal = {
   content: {
     main: {},
@@ -156,22 +175,9 @@ export const filterModal = {
           },
         },
         clearButton: {
-          main: {
-            pB: 5,
-            pH: 10,
-            jtC: 'flex-end',
-          },
-          content: {
-            $web: {
-              ltrS: 0.1,
-            },
-            $all: {
-              ftSz: 18,
-              ftWt: '500',
-              txDc: 'underline',
-              color: colors.lightGray01,
-            },
-          },
+          default: clearButtonDefault(),
+          active: clearButtonDefault(true),
+          hover: clearButtonDefault(true),
         },
       },
     },


### PR DESCRIPTION
**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-374)

## Context

* Filter Modal should contain a `clear filter` button. as shown in the new specs powerpoint here https://docs.google.com/presentation/d/19PRD8-W6hhWZvl8u1IPUOAkdnUJunCQ2zgGntuxM9Wk/edit?ts=5f58932a#slide=id.g8b8266aa53_0_208

* it should:
    * only display if any filter has been selected
    * on press > clears out currently selected filter. does NOT apply it automatically


## Goal

* Add this `clear filters` button on the filter modal
* use the already existing action `clearSelectedFilters`

## Updates

* `src/components/modals/filter.js`
   * add the button and attach the action `clearSelectedFilters`
   * minor cleanup

## Testing

* Run `keg dpg run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:zen-374-modal-filter-clear-btn`
* Open the filter modal > verify you dont see a `clear filters` button
* select some filters > verify you see the `clear filters` button now
* click on `clear filters` > verify that it clears out your selected filters



