### PR TITLE
replaced use of .flatMap fn with one from jsutils for Safari 11.1 error

### DIFF
--- a/src/utils/models/tickets/getAllBookedTickets.js
+++ b/src/utils/models/tickets/getAllBookedTickets.js
@@ -1,4 +1,4 @@
-import { exists } from '@keg-hub/jsutils'
+import { exists, flatMap } from '@keg-hub/jsutils'
 
 /**
  * Returns a list of all the booked tickets
@@ -11,8 +11,9 @@ export const getAllBookedTickets = bookedTickets => {
     ...bookedTickets,
 
     // sub tickets, flattened to the same level, and filter out any that are undefined
-    ...bookedTickets
-      .flatMap(({ bookedSubTickets }) => bookedSubTickets)
-      .filter(exists),
+    ...flatMap(
+      bookedTickets,
+      ({ bookedSubTickets }) => bookedSubTickets
+    ).filter(exists),
   ]
 }

--- a/src/utils/models/tickets/getAllBookedTickets.js
+++ b/src/utils/models/tickets/getAllBookedTickets.js
@@ -1,4 +1,4 @@
-import { exists, flatMap } from '@keg-hub/jsutils'
+import { exists } from '@keg-hub/jsutils'
 
 /**
  * Returns a list of all the booked tickets
@@ -11,9 +11,9 @@ export const getAllBookedTickets = bookedTickets => {
     ...bookedTickets,
 
     // sub tickets, flattened to the same level, and filter out any that are undefined
-    ...flatMap(
-      bookedTickets,
-      ({ bookedSubTickets }) => bookedSubTickets
-    ).filter(exists),
+    ...bookedTickets.reduce((allBookedTickets, { bookedSubTickets }) => {
+      exists(bookedSubTickets) && allBookedTickets.push(bookedSubTickets)
+      return allBookedTickets
+    }, []),
   ]
 }


### PR DESCRIPTION
## Context
* on Safari 11.1, the use of the Array prototype function `flatMap` is not supported

## Goals
* replace it with `reduce` code that does the same thing without relying on the unsupported function ( and is more efficient, to boot ) 

## Testing
* Nicole already tested this on Safari 11.1, and it passes.
* but this image is available to verify everything still works as expected (the code runs when the group booking modal opens): `keg evf pack run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:browser-compat-fixes`


