### PR TITLE
fixed bug where booked tickets didnt get flattened

### DIFF
--- a/src/utils/models/attendees/sortAttendeeIntoSections.js
+++ b/src/utils/models/attendees/sortAttendeeIntoSections.js
@@ -19,6 +19,7 @@ export const sortAttendeeIntoSections = (sectionData, nextAttendee) => {
     bookedTickets,
     tickets
   )
+
   if (!attendeeTicket) {
     devLog.warn('Could not find a valid ticket for attendee. Skipping... \n', {
       nextAttendee,

--- a/src/utils/models/tickets/getAllBookedTickets.js
+++ b/src/utils/models/tickets/getAllBookedTickets.js
@@ -12,7 +12,8 @@ export const getAllBookedTickets = bookedTickets => {
 
     // sub tickets, flattened to the same level, and filter out any that are undefined
     ...bookedTickets.reduce((allBookedTickets, { bookedSubTickets }) => {
-      exists(bookedSubTickets) && allBookedTickets.push(bookedSubTickets)
+      exists(bookedSubTickets) &&
+        bookedSubTickets.map(ticket => allBookedTickets.push(ticket))
       return allBookedTickets
     }, []),
   ]


### PR DESCRIPTION
## Context
* there was a bug with the mapping of the tickets based on the recent change, the sub tickets weren't getting flattened

## Goal
* fix bug

## Testing
* `keg evf pack run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:booked-ticket-mapping-fix`
* ensure that the `/test` page and the group booking modal loads, and verify that you see no warnings in the console about not finding a valid ticket (it would say "Could not find a valid ticket for attendee")
