### PR TITLE
Modal Style Updates + Fixed Tests

### DIFF
--- a/src/components/booking/attendeeCheckboxItem.js
+++ b/src/components/booking/attendeeCheckboxItem.js
@@ -109,13 +109,12 @@ const WaitingItem = props => {
       <View style={waitingStyles?.textWrapper}>
         <Text
           className={textClassName}
-          numberOfLines={1}
           style={[ waitingStyles?.text, textStyle ]}
           onPress={onPress}
         >
           { name }
+          { isMobile && ' (waiting)' }
         </Text>
-        { isMobile && <Text style={waitingStyles?.waitText}>(waiting)</Text> }
       </View>
       { !isMobile && <WaitingBox styles={waitingStyles?.waitBox} /> }
     </View>

--- a/src/components/modals/alert.js
+++ b/src/components/modals/alert.js
@@ -49,7 +49,7 @@ const Body = ({ styles, message, onButtonPress }) => {
   return (
     <View
       style={styles?.main}
-      className={`ef-modal-sub-header ef-modal-alert-body`}
+      className={[ 'ef-modal-sub-header', 'ef-modal-alert-body' ]}
     >
       <ScrollView
         style={styles?.textContainer?.main}

--- a/src/components/modals/baseModal.js
+++ b/src/components/modals/baseModal.js
@@ -115,8 +115,7 @@ export const BaseModal = props => {
         setDismissed={setDismissed}
         hasCloseButton={hasCloseButton}
       />
-
-      { children }
+      <View style={baseStyles.content.bodyWrapper}>{ children }</View>
     </Modal>,
     document.body
   )

--- a/src/hooks/booking/__tests__/useBookingLists.js
+++ b/src/hooks/booking/__tests__/useBookingLists.js
@@ -6,7 +6,12 @@ const mocks = {
   useRestrictedAttendeeIds: () => ({ isBookable: () => true }),
 }
 
+const reactMocks = {
+  useMemo: (...args) => args[0](),
+}
+
 jest.setMock('../useRestrictedAttendeeIds', mocks)
+jest.setMock('react', reactMocks)
 
 const useBookingLists = (...args) =>
   require('../useBookingLists').useBookingLists(...args)
@@ -28,6 +33,10 @@ const noWaitingListSession = deepMerge(limitedSession, {
 const allAttendeeIds = testData.attendees.map(att => att.bookedTicketIdentifier)
 
 describe('useBookingLists', () => {
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
+
   afterEach(() => {
     mocks.useRestrictedAttendeeIds = () => ({ isBookable: () => true })
   })

--- a/src/mocks/eventsforce/testData.js
+++ b/src/mocks/eventsforce/testData.js
@@ -376,7 +376,7 @@ export default {
     },
     {
       bookedTicketIdentifier: '2',
-      name: "Mrs Penelope O'Connor",
+      name: "Mrs Penelope O'Connor the Second",
       attendeeCategoryIdentifier: '2',
       bookedDays: [2],
       bookedSessions: [],

--- a/src/theme/components/booking/attendeeCheckboxItem.js
+++ b/src/theme/components/booking/attendeeCheckboxItem.js
@@ -3,11 +3,14 @@ import { colors } from '../../colors'
 const text = {
   $xsmall: {
     fontSize: '0.8em',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    flexShrink: 1,
+    overflow: 'visible',
   },
   $small: {
     fontSize: 'inherit',
   },
-  overflow: 'visible',
 }
 
 export const attendeeCheckboxItem = {
@@ -20,20 +23,17 @@ export const attendeeCheckboxItem = {
         alignItems: 'center',
         justifyContent: 'flex-start',
         marginLeft: 10,
+        flexWrap: 'wrap',
       },
       $small: {
         justifyContent: 'space-between',
       },
     },
     textWrapper: {
-      flexDirection: 'row',
+      flexDirection: 'column',
+      flexShrink: 1,
     },
     text,
-    waitText: {
-      ...text,
-      fontStyle: 'italic',
-      marginLeft: 4,
-    },
     waitBox: {
       main: {
         $web: {

--- a/src/theme/components/booking/attendeeCheckboxItem.js
+++ b/src/theme/components/booking/attendeeCheckboxItem.js
@@ -27,6 +27,7 @@ export const attendeeCheckboxItem = {
       },
       $small: {
         justifyContent: 'space-between',
+        flexWrap: 'nowrap',
       },
     },
     textWrapper: {

--- a/src/theme/components/modals/alertModal.js
+++ b/src/theme/components/modals/alertModal.js
@@ -21,7 +21,6 @@ export const alertModal = {
           $all: {
             $xsmall: {
               letterSpacing: 0.105,
-              paddingLeft: 26,
             },
             $small: {},
           },
@@ -29,10 +28,6 @@ export const alertModal = {
       },
     },
     body: {
-      main: {
-        paddingHorizontal: 22,
-        paddingVertical: 26,
-      },
       textContainer: {
         main: {
           $xsmall: {

--- a/src/theme/components/modals/baseModal.js
+++ b/src/theme/components/modals/baseModal.js
@@ -21,6 +21,17 @@ export const baseModal = {
         },
       },
     },
+    bodyWrapper: {
+      $xsmall: {
+        flex: 1,
+        paddingHorizontal: 18,
+        paddingVertical: 12,
+      },
+      $small: {
+        paddingHorizontal: 40,
+        paddingVertical: 25,
+      },
+    },
     header: {
       main: {
         flexDirection: 'row',
@@ -32,11 +43,16 @@ export const baseModal = {
           $xsmall: {
             alignSelf: 'center',
             color: colors.white,
-            paddingLeft: 46,
-            paddingRight: 30,
+            paddingLeft: 18,
+            paddingRight: 16,
+            fontSize: 17,
             fontWeight: '600',
-            fontSize: 18,
             lineHeight: 27,
+          },
+          $small: {
+            fontSize: 18,
+            paddingLeft: 40,
+            paddingRight: 30,
           },
         },
         closeButton: {

--- a/src/theme/components/modals/filterModal.js
+++ b/src/theme/components/modals/filterModal.js
@@ -123,9 +123,6 @@ export const filterModal = {
     },
     body: {
       main: {
-        paddingLeft: 46,
-        paddingRight: 26,
-        paddingTop: 17,
         paddingBottom: 26,
       },
       topSection: {
@@ -169,7 +166,7 @@ export const filterModal = {
         applyButton: {
           main: {
             minHeight: 45,
-            mL: 15
+            mL: 15,
           },
         },
         clearButton: clearButtonDefault,

--- a/src/theme/components/modals/filterModal.js
+++ b/src/theme/components/modals/filterModal.js
@@ -122,9 +122,7 @@ export const filterModal = {
       },
     },
     body: {
-      main: {
-        paddingBottom: 26,
-      },
+      main: {},
       topSection: {
         main: {
           flexDirection: 'row',

--- a/src/theme/components/modals/groupBookingModal.js
+++ b/src/theme/components/modals/groupBookingModal.js
@@ -25,17 +25,7 @@ export const groupBookingModal = {
       main: {
         $xsmall: {
           flexDirection: 'column',
-          paddingLeft: 18,
-          paddingRight: 16,
-          paddingTop: 7,
-
-          // allows for both overflow-scrolling AND dynamic flex sizing
           flexShrink: 'unset',
-        },
-        $small: {
-          paddingLeft: 46,
-          paddingRight: 36,
-          paddingTop: 17,
         },
       },
       content: {
@@ -81,7 +71,7 @@ export const groupBookingModal = {
               flexDirection: 'row',
               alignSelf: 'flex-end',
               paddingTop: 26,
-              paddingBottom: 36,
+              paddingBottom: 18,
             },
           },
           content: {

--- a/src/theme/components/modals/groupBookingModal.js
+++ b/src/theme/components/modals/groupBookingModal.js
@@ -70,8 +70,12 @@ export const groupBookingModal = {
               flex: 1,
               flexDirection: 'row',
               alignSelf: 'flex-end',
-              paddingTop: 26,
+              paddingTop: 14,
               paddingBottom: 18,
+            },
+            $small: {
+              paddingTop: 26,
+              paddingBottom: 0,
             },
           },
           content: {

--- a/src/theme/components/modals/presenterDetailsModal.js
+++ b/src/theme/components/modals/presenterDetailsModal.js
@@ -36,8 +36,6 @@ export const presenterDetailsModal = {
     body: {
       main: {
         flex: 1,
-        paddingHorizontal: 40,
-        paddingVertical: 25,
       },
       row1: {
         smallImage,

--- a/src/theme/components/modals/sessionDetailsModal.js
+++ b/src/theme/components/modals/sessionDetailsModal.js
@@ -5,16 +5,13 @@ const defaultHeaderTextStyle = {
   ftWt: '600',
   lnH: 19,
 }
+
 export const sessionDetailsModal = {
   main: {},
   content: {
     main: {},
     body: {
-      main: {
-        pH: 43,
-        pT: 50,
-        pB: 21,
-      },
+      main: {},
       dateTimeText: defaultHeaderTextStyle,
       locationText: {
         mT: 13,


### PR DESCRIPTION
## Context
* modal padding was not consistent and each modal was redefining its own padding/margins'
* in group booking modal, very long names that were also on waiting list weren't wrapping
* `useBookingLists` tests were failing

## Goal

* Make all modal bodies use the same padding, to be consistent and less brittle
* Make long waiting-list names wrap on small screen widths
* Fix `useBookingLists` tests

## Updates

* `src/components/booking/attendeeCheckboxItem.js`
  * updates to get it wrapping
* `src/components/modals/baseModal.js`
  * updated to wrap modal children in a view that can define consistent padding in a single place
* `src/hooks/booking/__tests__/useBookingLists.js`
  * fixed tests by mocking out `useMemo`, also added a `jest.resetAllMocks()` call after all tests run
* `**/**.js`
  * updated all the other modals and themes to remove inconsistent margins and padding, except where it needed additional padding

## Testing

* `keg evf pack run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:consistent-modal-padding`
* for each modal (alert, group booking, session details, filter, presenter):
  * verify everything looks like you would expect
  * verify the content of the modal lines up the the modal header's title
* run `yarn test`, verify all tests pass
  * EXCEPT `useInterval`. Something is still breaking this test (`useRef` is blocking and preventing the test from completing before the timeout), but it precedes my group booking changes so I will investigate this in a separate PR
