### PR TITLE
GridItem Height fix

### DIFF
--- a/src/components/grid/gridTileContent.js
+++ b/src/components/grid/gridTileContent.js
@@ -115,15 +115,17 @@ const PresenterNames = React.memo(({ session, styles }) => {
 
   return (
     <View style={styles?.main}>
-      { presenters.map(presenter => {
-        return (
-          <PresenterLink
-            key={presenter.identifier}
-            styles={styles?.sessionLink}
-            presenter={presenter}
-          />
-        )
-      }) }
+      <View style={styles?.container}>
+        { presenters.map(presenter => {
+          return (
+            <PresenterLink
+              key={presenter.identifier}
+              styles={styles?.sessionLink}
+              presenter={presenter}
+            />
+          )
+        }) }
+      </View>
     </View>
   )
 })

--- a/src/components/sessionLink/sessionLink.js
+++ b/src/components/sessionLink/sessionLink.js
@@ -9,8 +9,9 @@ import { isMobileSize } from 'SVUtils/theme'
  * @param {Function} props.onPress
  * @param {string} props.text - text to display
  * @param {object} props.styles
+ * @param {string} props.className
  */
-export const SessionLink = ({ onPress, text, styles }) => {
+export const SessionLink = ({ onPress, text, styles, className }) => {
   const theme = useTheme()
   const sessionLinkStyles = useStyle('sessionLink.default')
   const numberOfLines = useMemo(

--- a/src/mocks/eventsforce/testData.js
+++ b/src/mocks/eventsforce/testData.js
@@ -3,7 +3,7 @@ import { longText } from '../text'
 export default {
   displayProperties: {
     dateFormat: 'dd/MM/yyyy', // can be "dd/MM/yyyy" | "MM/dd/yyyy" | "yyyy-MM-dd"
-    timeFormat: '12' // can be '12' or '24'
+    timeFormat: '12', // can be '12' or '24'
   },
   agendaDays: [
     {
@@ -66,6 +66,23 @@ export default {
       email: 'b_flay@gmail.com',
       jobtitle: 'Janitor',
       company: 'Simpleview',
+      biography: longText,
+    },
+    {
+      identifier: '5',
+      firstname: 'Foo',
+      lastname: 'Bar',
+      email: 'foobar@gmail.com',
+      jobtitle: 'Engineer',
+      company: 'Google Inc',
+      biography: longText,
+    },
+    {
+      identifier: '6',
+      firstname: 'Jonny',
+      lastname: 'Jonathan',
+      email: 'jojo@gmail.com',
+      jobtitle: 'Freelancer',
       biography: longText,
     },
   ],
@@ -237,7 +254,8 @@ export default {
     {
       allowBooking: true,
       identifier: '6',
-      name: 'Session on day 2 restricted to attendee category',
+      name:
+        'Session on day 2 restricted to attendee categorySession on day 2 restricted to attendee categorySession on day 2 restricted to attendee categorySession on day 2 restricted to attendee categorySession on day 2 restricted to attendee categorySession on day 2 restricted to attendee categorySession on day 2 restricted to attendee categorySession on day 2 restricted to attendee category',
       summary: '',
       dayNumber: 2,
       startDateTimeLocal: '2020-08-04 11:00:00',
@@ -260,7 +278,7 @@ export default {
       dayNumber: 2,
       startDateTimeLocal: '2020-08-04 11:00:00',
       endDateTimeLocal: '2020-08-04 11:45:00',
-      presenterIdentifiers: [],
+      presenterIdentifiers: [ '2', '3', '4' ],
       labelIdentifiers: [],
       locationIdentifier: '2',
       liveVideoUrl: '',
@@ -276,12 +294,12 @@ export default {
       allowBooking: true,
       identifier: '8',
       name:
-        'Session on day 2 Demo 2: super long name. Something different that is very complicated to describe',
+        'Session on day 2 Demo 2: super long name. Something different that is very complicated to describesession with presenters and labels session with presenters and labels',
       summary: '',
       dayNumber: 2,
       startDateTimeLocal: '2020-08-04 11:00:00',
       endDateTimeLocal: '2020-08-04 11:30:00',
-      presenterIdentifiers: [],
+      presenterIdentifiers: [ '1', '2', '3', '4', '5', '6' ],
       labelIdentifiers: ['6'],
       locationIdentifier: '2',
       liveVideoUrl: '',

--- a/src/theme/components/grid/gridItem.js
+++ b/src/theme/components/grid/gridItem.js
@@ -21,11 +21,6 @@ export const gridItem = {
         minHeight: 294,
       },
     },
-    $web: {
-      $xsmall: {
-        height: 'fit-content',
-      },
-    },
   },
   gridTileContent,
   gridRowContent,

--- a/src/theme/components/grid/gridTileContent.js
+++ b/src/theme/components/grid/gridTileContent.js
@@ -26,9 +26,11 @@ export const gridTileContent = {
   },
   presenters: {
     main: {
-      flD: 'row',
-      mR: 79,
+      fl: 1,
+    },
+    container: {
       flWr: 'wrap',
+      flD: 'row',
     },
     sessionLink: {
       main: {
@@ -44,8 +46,7 @@ export const gridTileContent = {
   buttonSection: {
     main: {
       $web: {
-        position: 'absolute',
-        bottom: 0,
+        position: 'relative',
         alignSelf: 'flex-end',
       },
     },


### PR DESCRIPTION
**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-425)

## Context

* Each grid item has a dynamic height and minHeight of 294px (from mockup)
* The grid item(s) in each block container (IF they are on the same row) should have the same height
    * it should not do this
       * ![image](https://user-images.githubusercontent.com/3317835/97214150-e11d2080-177f-11eb-9854-37a6ee9738d1.png)


## Goal

* Update styling on the grid item and gridTileContent so that the height of each item grows accordingly

## Updates
- `src/mocks/eventsforce/testData.js`
    - updated mockdata with more presenters
- `src/components/sessionLink/sessionLink.js`
    - added className to sessionLink, so we can override it for presenter name classname
- `src/theme/components/grid/gridTileContent.js`
    - wrapped presenterNames in a container so it can be dynamically grow
- `src/theme/components/grid/gridItem.js`
    - removed fit-content from gridItem, so each grid item can grow if they need to
- `src/components/grid/gridTileContent.js`
    - updated styling on grid tile content so the button is relative

## Testing

* Run `keg dpg run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:zen-425-griditem-height`
* navigate to **Day 2** > Timeblock 11:00 AM.  OR add a bunch of session item to a specific time block
* Verify that all the items on the same row have the same height
     * ![image](https://user-images.githubusercontent.com/3317835/97214261-16297300-1780-11eb-941f-f7fcf8a147fa.png)

* Update the content of a session in that timeblock.
    * *I Modified the location name*
* verify that the height adjusts accordingly for sessions in the same row
    * ![image](https://user-images.githubusercontent.com/3317835/97214584-8b954380-1780-11eb-8a2a-94670de4657c.png)


### Unit test
* `keg dpg run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:zen-425-griditem-height command=test`
* ensure all test passes