### PR TITLE
Zen 424 session link underline

### DIFF
--- a/src/components/sessionLink/sessionLink.js
+++ b/src/components/sessionLink/sessionLink.js
@@ -12,14 +12,14 @@ import { isMobileSize } from 'SVUtils/theme'
  */
 export const SessionLink = ({ onPress, text, styles }) => {
   const theme = useTheme()
-  const sessionLinkStyles = useStyle('sessionLink.default', styles)
+  const sessionLinkStyles = useStyle('sessionLink.default')
   const numberOfLines = useMemo(
     () => (isMobileSize(theme) ? { numberOfLines: 2 } : { numberOfLines: 0 }),
     [theme]
   )
   // apply hover state
   const [ ref, themeStyle ] = useThemeHover(
-    theme.join(sessionLinkStyles, styles),
+    useStyle(sessionLinkStyles, styles),
     useStyle(`sessionLink.hover`)
   )
 

--- a/src/components/sessionLink/sessionLink.js
+++ b/src/components/sessionLink/sessionLink.js
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
 import { Text, Touchable } from '@keg-hub/keg-components'
-import { useStyle, useTheme } from '@keg-hub/re-theme'
+import { useStyle, useTheme, useThemeHover } from '@keg-hub/re-theme'
 import { isMobileSize } from 'SVUtils/theme'
 
 /**
@@ -12,22 +12,28 @@ import { isMobileSize } from 'SVUtils/theme'
  */
 export const SessionLink = ({ onPress, text, styles }) => {
   const theme = useTheme()
-  const sessionLinkStyles = useStyle('sessionLink', styles)
+  const sessionLinkStyles = useStyle('sessionLink.default', styles)
   const numberOfLines = useMemo(
     () => (isMobileSize(theme) ? { numberOfLines: 2 } : { numberOfLines: 0 }),
     [theme]
+  )
+  // apply hover state
+  const [ ref, themeStyle ] = useThemeHover(
+    theme.join(sessionLinkStyles, styles),
+    useStyle(`sessionLink.hover`)
   )
 
   return (
     <Touchable
       activeOpacity={onPress ? 0.2 : 1}
       onPress={onPress}
-      style={sessionLinkStyles.main}
+      style={themeStyle.main}
       pointerEvents={onPress ? 'auto' : 'none'}
     >
       <Text
+        ref={ref}
         {...numberOfLines}
-        style={sessionLinkStyles.text}
+        style={themeStyle.text}
         className='ef-session-name'
       >
         { text }

--- a/src/theme/components/button/evfButton.js
+++ b/src/theme/components/button/evfButton.js
@@ -49,7 +49,7 @@ const buildButtonState = stateStyles =>
           flex: 1,
           justifyContent: 'center',
           borderRadius: 0,
-          height: 50,
+          minHeight: 50,
         },
         $web: {
           boxShadow: '0px 1px 1px rgba(0, 0, 0, 0.15)',

--- a/src/theme/components/grid/gridTileContent.js
+++ b/src/theme/components/grid/gridTileContent.js
@@ -1,15 +1,5 @@
 import { colors } from '../../colors'
 
-const presenterSessionLink = {
-  main: {
-    $xsmall: {
-      mT: 13,
-    },
-    $small: {
-      mR: 10,
-    },
-  },
-}
 export const gridTileContent = {
   main: {
     flex: 1,
@@ -41,8 +31,14 @@ export const gridTileContent = {
       flWr: 'wrap',
     },
     sessionLink: {
-      default: presenterSessionLink,
-      hover: presenterSessionLink,
+      main: {
+        $xsmall: {
+          mT: 13,
+        },
+        $small: {
+          mR: 10,
+        },
+      },
     },
   },
   buttonSection: {

--- a/src/theme/components/grid/gridTileContent.js
+++ b/src/theme/components/grid/gridTileContent.js
@@ -1,5 +1,15 @@
 import { colors } from '../../colors'
 
+const presenterSessionLink = {
+  main: {
+    $xsmall: {
+      mT: 13,
+    },
+    $small: {
+      mR: 10,
+    },
+  },
+}
 export const gridTileContent = {
   main: {
     flex: 1,
@@ -31,14 +41,8 @@ export const gridTileContent = {
       flWr: 'wrap',
     },
     sessionLink: {
-      main: {
-        $xsmall: {
-          mT: 13,
-        },
-        $small: {
-          mR: 10,
-        },
-      },
+      default: presenterSessionLink,
+      hover: presenterSessionLink,
     },
   },
   buttonSection: {

--- a/src/theme/components/sessionLink.js
+++ b/src/theme/components/sessionLink.js
@@ -1,5 +1,4 @@
 import { colors } from '../colors'
-import { deepMerge } from '@keg-hub/jsutils'
 
 const mainStyle = {
   $xsmall: {
@@ -41,10 +40,12 @@ export const sessionLink = {
     text: textStyle,
   },
   hover: {
-    text: deepMerge(textStyle, {
+    text: {
       $all: {
-        $xsmall: { txDL: 'underline' },
+        $xsmall: { 
+          txDL: 'underline' 
+        },
       },
-    }),
+    },
   },
 }

--- a/src/theme/components/sessionLink.js
+++ b/src/theme/components/sessionLink.js
@@ -3,13 +3,13 @@ import { deepMerge } from '@keg-hub/jsutils'
 
 const mainStyle = {
   $xsmall: {
-    marginTop: 5,
-    marginRight: 20,
-    flexWrap: 'wrap',
+    mT: 5,
+    mR: 20,
+    flWr: 'wrap',
   },
   $small: {
-    marginTop: 29,
-    marginRight: 79,
+    mT: 29,
+    mR: 79,
   },
 }
 
@@ -41,7 +41,6 @@ export const sessionLink = {
     text: textStyle,
   },
   hover: {
-    main: mainStyle,
     text: deepMerge(textStyle, {
       $all: {
         $xsmall: { txDL: 'underline' },

--- a/src/theme/components/sessionLink.js
+++ b/src/theme/components/sessionLink.js
@@ -1,36 +1,51 @@
 import { colors } from '../colors'
+import { deepMerge } from '@keg-hub/jsutils'
 
-export const sessionLink = {
-  main: {
+const mainStyle = {
+  $xsmall: {
+    marginTop: 5,
+    marginRight: 20,
+    flexWrap: 'wrap',
+  },
+  $small: {
+    marginTop: 29,
+    marginRight: 79,
+  },
+}
+
+const textStyle = {
+  $web: {
+    width: 'fit-content',
+  },
+  $native: {
+    flD: 'row',
+    alS: 'flex-start',
+  },
+  $all: {
     $xsmall: {
-      marginTop: 5,
-      marginRight: 20,
-      flexWrap: 'wrap',
+      c: colors.black,
+      ftSz: 14,
+      lnH: 17,
     },
     $small: {
-      marginTop: 29,
-      marginRight: 79,
+      c: colors.primary,
+      ftSz: 16,
+      lnH: 19,
     },
   },
-  text: {
-    $web: {
-      width: 'fit-content',
-    },
-    $native: {
-      flexDirection: 'row',
-      alignSelf: 'flex-start',
-    },
-    $all: {
-      $xsmall: {
-        color: colors.black,
-        fontSize: 14,
-        lineHeight: 17,
+}
+
+export const sessionLink = {
+  default: {
+    main: mainStyle,
+    text: textStyle,
+  },
+  hover: {
+    main: mainStyle,
+    text: deepMerge(textStyle, {
+      $all: {
+        $xsmall: { txDL: 'underline' },
       },
-      $small: {
-        color: colors.primary,
-        fontSize: 16,
-        lineHeight: 19,
-      },
-    },
+    }),
   },
 }


### PR DESCRIPTION
**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-424)

## Context

* Going back over the RegX5 session doc here https://docs.google.com/document/d/1bZIMvNhg6fsU5Tf1edLcoBfpu8rR9qQLGf0Kx-DGMrw/edit#
* minor detailed that was missed is that the link should become underlined when hovered

## Goal

* Make session link and presenter link underline on hover

## Updates

* `src/components/sessionLink/sessionLink.js`
  * added useThemeHover hook
  * added the theme ref to the Text component

* `src/theme/components/sessionLink.js`
   * added default and hover state styles

## Testing

* run `keg dpg run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:zen-424-session-link-underline`
* verify that the Session link and presenter link is underlined when you hover them 
* ![image](https://user-images.githubusercontent.com/3317835/97372929-f6727780-1871-11eb-97d1-ecbfbc011589.png)
