### PR TITLE
Zen 428 preselecting bug

### DIFF
--- a/src/hooks/booking/useBookingLists.js
+++ b/src/hooks/booking/useBookingLists.js
@@ -18,7 +18,7 @@ const getInitialWaitIds = (session, attendees, isBookable) => {
 /**
  * Builds the initial list of booked attendee ids for the session
  * @param {Object} session - session object
- * @param {Array<string>} attendees - full list of attendees
+ * @param {Array<import('SVModels/Attendee').Attendee>} attendees - full list of attendees
  * @param {Array<string>} initialWaitIds - list of ids on the initial waiting list
  * @param {Function} isBookable - cb of form: attendeeId => true/false if bookable/waitListable to the session
  * @param {boolean} initialCapacityExceedsNeed - true if the initial capacity exceeds the potential
@@ -35,7 +35,7 @@ const getInitialBookingIds = (
   // include all the attendees that are bookable
   if (initialCapacityExceedsNeed && !initialWaitIds?.length)
     return attendees.reduce((ids, nextAttendee) => {
-      if (!isBookable(nextAttendee)) return ids
+      if (!isBookable(nextAttendee.bookedTicketIdentifier)) return ids
       ids.push(nextAttendee.bookedTicketIdentifier)
       return ids
     }, [])

--- a/src/hooks/booking/useRestrictedAttendeeIds.js
+++ b/src/hooks/booking/useRestrictedAttendeeIds.js
@@ -1,11 +1,28 @@
 import { useMemo } from 'react'
 import { useStoreItems } from 'SVHooks/store/useStoreItems'
+import { validate, isStr } from '@keg-hub/jsutils'
+
+/**
+ * Helper for `useRestrictedAttendeeIds`. Builds an
+ * `isBookable` function returned by that hook, with validation
+ * @param {Array<string>?} restrictedIdsForSession
+ */
+const getIsBookable = restrictedIdsForSession => {
+  return attendeeId => {
+    const [valid] = validate({ attendeeId }, { attendeeId: isStr })
+    if (!valid) return false
+    return (
+      restrictedIdsForSession && !restrictedIdsForSession.includes(attendeeId)
+    )
+  }
+}
 
 /**
  * Returns an object with the following properties:
  *  - restrictedAttendeeIds: map of restricted attendee ids by session
  *  - restrictedAttendeeIdsForSession: the attendee ids for this sessionId
- *  - isBookable: a function indicating an attendee can book a given session. If it returns false, that attendee is restricted from booking.
+ *  - isBookable: a function indicating an attendee (id) can book a given session.
+ *                If it returns false, that attendee with that id is restricted from booking.
  * @param {string?} sessionId - id of session - only required if you want helper fn isBookable
  * @return {Object} restricted data
  */
@@ -16,8 +33,7 @@ export const useRestrictedAttendeeIds = sessionId => {
     () => ({
       restrictedAttendeeIds,
       restrictedIdsForSession,
-      isBookable: id =>
-        restrictedIdsForSession && !restrictedIdsForSession.includes(id),
+      isBookable: getIsBookable(restrictedIdsForSession),
     }),
     [ restrictedAttendeeIds, sessionId ]
   )


### PR DESCRIPTION
**Ticket**: [ZEN-428](https://jira.simpleviewtools.com/browse/ZEN-428)

## Context

* There's a bug causing restricted attendees to be preselected in the groupbooking modal

## Goal

* Ensure restricted attendees are never pre-selected

## Updates

* `src/hooks/booking/useBookingLists.js`
  * fixed call to `isBookable`, which was erroneously being passed an attendee object, rather than its id. 

* `src/hooks/booking/useRestrictedAttendeeIds.js`
  * did some refactoring, and added a validate call to help prevent this error in the future
  
## Testing

* `keg evf pack run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:zen-428-preselecting-bug`

* navigate to `Day 2` on `local.kegdev.xyz`
* scroll to the bottom, and press the `Select` button on the last session (`Session on day 2 Demo 3`)
* ensure everybody **except** `Mrs. Penelope`, `Vic Vinegar`, and `Hugh Honey` are preselected
  * these attendees have attendee categories that are not members of the `restrictToAttendeeCategories` list of the session
* if you want, try out any other unlimited sessions, and verify that you never see a greyed-out attendee who is also pre-selected
