### PR TITLE
fixed className for labelTag

### DIFF
--- a/src/components/labels/labelTag.js
+++ b/src/components/labels/labelTag.js
@@ -13,7 +13,7 @@ export const LabelTag = ({ label = {}, styles }) => {
   const theme = useTheme()
   return (
     <View
-      className={`ef-label-tag ${label.className}`}
+      className={[ 'ef-label-tag', label.className ]}
       style={[
         theme.get(`eventsForce.labels.${label.className}`),
         theme.get('labelTag.main'),


### PR DESCRIPTION
**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-447)

`[semver]: patch`
## Context

* related to https://github.com/simpleviewinc/keg-hub/pull/66
* i noticed the className wasn't setup properly for labelTag

## Goal
* fix it

## Updates

* `src/components/labels/labelTag.js`
   * should be an array of strings

## Testing

* testing covered in https://github.com/simpleviewinc/keg-hub/pull/66
