### PR TITLE
Theme As Functions

### DIFF
--- a/apps/Main.js
+++ b/apps/Main.js
@@ -2,7 +2,7 @@ import '../src/theme/theme.config'
 import React, { useState, useEffect } from 'react'
 import { theme } from 'SVTheme'
 import { SafeAreaView, StatusBar } from 'react-native'
-import { getDefaultTheme, setDefaultTheme, ReThemeProvider } from '@keg-hub/re-theme'
+import { getDefaultTheme, ReThemeProvider } from '@keg-hub/re-theme'
 import { Provider } from 'react-redux'
 import { getStore } from 'SVStore'
 import { initAppAction } from 'SVActions'
@@ -16,8 +16,6 @@ import { isNative } from 'SVUtils/platform'
 // IMPORTANT - should not be imported into the main sessions component export
 // This is for DEVELOPMENT only
 import "bootstrap/dist/css/bootstrap.min.css"
-
-setDefaultTheme(theme)
 
 const checkAppInit = setInit => {
   initAppAction?.()

--- a/apps/Sessions.js
+++ b/apps/Sessions.js
@@ -4,9 +4,7 @@ import { theme } from 'SVTheme'
 import {
   ReThemeProvider,
   getDefaultTheme,
-  setDefaultTheme,
   setRNDimensions,
-  setRNPlatform
 } from '@keg-hub/re-theme'
 import { Provider } from 'react-redux'
 import { getStore } from 'SVStore'
@@ -14,8 +12,6 @@ import { SessionsContainer } from 'SVContainers/sessionsContainer'
 import { Dimensions, Platform } from 'react-native'
 
 setRNDimensions(Dimensions)
-setRNPlatform(Platform)
-setDefaultTheme(theme)
 
 /**
  * The sessions app for events force. This is the entry point of the 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 /**
  * NOTE: any changes made on this file should exists in apps/Sessions.js if you want access to it in the Sessions export
  */
-import './src/mocks/eventsforce/testStyles.css'
 import App from 'SVTapEntry'
 export {
   App

--- a/src/theme/tapIndex.js
+++ b/src/theme/tapIndex.js
@@ -1,16 +1,30 @@
-import { deepMerge } from '@keg-hub/jsutils'
 import { app } from './app'
-import { eventsForce } from './eventsForce'
-import { kegComponentsTheme } from 'SVTheme/kegComponentsTheme'
-import * as components from './components'
-import * as containers from './containers'
 import { colors } from './colors'
 import { typography } from './typography'
+import * as components from './components'
+import * as containers from './containers'
+import { eventsForce } from './eventsForce'
+import { deepMerge, noOpObj } from '@keg-hub/jsutils'
+import { setDefaultTheme } from '@keg-hub/re-theme'
+import { kegComponentsTheme } from 'SVTheme/kegComponentsTheme'
 
-export const theme = deepMerge(
-  kegComponentsTheme,
-  { eventsForce: { labels: eventsForce } },
-  { app, colors, typography },
-  components,
-  containers
+/**
+ * Custom theme config object
+ * Allows overwriting the theme defaults for keg-components
+ */
+const themeConfig = {
+  defaults: noOpObj,
+}
+
+export const theme = setDefaultTheme(
+  kegComponentsTheme(
+    themeConfig,
+    // Pass in custom theme values to be added to the global theme object
+    deepMerge(
+      { eventsForce: { labels: eventsForce } },
+      { app, colors, typography },
+      components,
+      containers
+    )
+  )
 )


### PR DESCRIPTION
[Semver-Status] patch

> This PR should be reviewed along with [this PR](https://github.com/simpleviewinc/keg-hub/pull/72)

## Context
* Currently there is no way to overwrite the default theme config
* Keg-Components has been updated to allow dynamically setting the Theme
* This allows overwriting the default theme config

## Goal

* Should allow overwriting the default theme config

## Updates

* `apps/Main.js` && `apps/Sessions.js`
  * Moved call to setDefaultTheme to theme file
* Removed `setRNPlatform` call. It's no longer needed
* `src/theme/tapIndex.js`
  * Updated to call theme initialize function


## Testing

* Run the docker package => `keg evf pack run docker.pkg.github.com/simpleviewinc/keg-packages/tap:keg-theme-as-functions`
* Navigate to this URL => http://evf-keg-theme-as-functions.local.kegdev.xyz/
  * Ensure everything looks exactly the same as before
  * There should be no difference between the current EVF Tap styles, and the changes from this branch

