### PR TITLE
grid item bug fix

### DIFF
--- a/src/assets/icons/evf/elements/filter.js
+++ b/src/assets/icons/evf/elements/filter.js
@@ -2,11 +2,9 @@ import * as React from 'react'
 import { SvgIcon } from '@keg-hub/keg-components'
 
 export function Filter(props) {
+  console.log(props, 'hehe')
   return (
     <SvgIcon
-      width={23}
-      height={21}
-      viewBox='0 0 23 21'
       svgFill='none'
       stroke='none'
       {...props}

--- a/src/assets/icons/evf/elements/filter.js
+++ b/src/assets/icons/evf/elements/filter.js
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { SvgIcon } from '@keg-hub/keg-components'
 
 export function Filter(props) {
-  console.log(props, 'hehe')
   return (
     <SvgIcon
       svgFill='none'

--- a/src/theme/components/grid/gridItem.js
+++ b/src/theme/components/grid/gridItem.js
@@ -11,12 +11,11 @@ export const gridItem = {
         alignItems: 'flex-start',
       },
       $small: {
-        flex: 1,
+        flex: '1 1 333px',
         marginHorizontal: 3,
         marginBottom: 6,
         padding: 15,
         paddingTop: 20,
-        flexBasis: 333,
         flexDirection: 'column',
         minHeight: 294,
       },

--- a/src/theme/components/grid/gridItem.js
+++ b/src/theme/components/grid/gridItem.js
@@ -11,13 +11,17 @@ export const gridItem = {
         alignItems: 'flex-start',
       },
       $small: {
-        flex: '1 1 333px',
         marginHorizontal: 3,
         marginBottom: 6,
         padding: 15,
         paddingTop: 20,
         flexDirection: 'column',
         minHeight: 294,
+      },
+    },
+    $web: {
+      $small: {
+        flex: '1 1 333px',
       },
     },
   },

--- a/src/theme/components/labelList.js
+++ b/src/theme/components/labelList.js
@@ -18,7 +18,6 @@ export const labelList = {
         alignContent: 'flex-start',
         flexWrap: 'wrap',
         maxWidth: '100%',
-        flexBasis: 'auto',
       },
     },
   },

--- a/src/theme/components/modals/filterModal.js
+++ b/src/theme/components/modals/filterModal.js
@@ -84,7 +84,6 @@ const buttonsWrapper = {
       alignContent: 'flex-start',
       flexWrap: 'wrap',
       maxWidth: '100%',
-      flexBasis: 'auto',
       paddingBottom: 20,
     },
     $small: {

--- a/src/theme/components/sessionTime.js
+++ b/src/theme/components/sessionTime.js
@@ -28,7 +28,7 @@ export const sessionTime = {
   },
   timeText: {
     main: {
-      flexBasis: 200,
+      flex: '1 1 200px',
       width: 0,
     },
     content: {

--- a/src/theme/components/sessionTime.js
+++ b/src/theme/components/sessionTime.js
@@ -28,8 +28,10 @@ export const sessionTime = {
   },
   timeText: {
     main: {
-      flex: '1 1 200px',
-      width: 0,
+      $web: {
+        flex: '1 1 200px',
+        width: 0,
+      },
     },
     content: {
       $xsmall: {

--- a/src/theme/components/sessions.js
+++ b/src/theme/components/sessions.js
@@ -107,6 +107,8 @@ export const sessions = {
                 $xsmall: {
                   color: colors.black,
                   paddingRight: 5,
+                  height: 21,
+                  width: 32,
                 },
                 $small: {
                   paddingRight: 10,


### PR DESCRIPTION
**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-459)

## Context

* there appears to be a breaking change when upgrading to react-native-web 14.x regarding `flexBasis`
* this caused the gridItem flexBasis to not get applied properly

## Goal

- fixed a bug with filter icon sizing
- fixed gridItem flexBasis width

## Updates

* `src/assets/icons/evf/elements/filter.js`
   * removed default values from filter icon svg, we just set the height in the styles
   * there was an issue where the icon size was too small when the default values was there

* `src/theme/components/grid/gridItem.js`
    * set the flexBasis values in the `flex`key

* `src/theme/components/labelList.js`
    * uneeded style removed

* `src/theme/components/modals/filterModal.js`
   * uneeded style removed

## Testing

* run `keg evf pack run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:zen-459-flex-basis-fix`
* navigate to http://evf-zen-459-flex-basis-fix.local.kegdev.xyz/
* navigate to `Day 2`
* scroll down to the **11:00 AM** block
* resize the browser width
* verify that the grid item adjusts accordingly and no item is overflowing
