### PR TITLE
Fix Rollup Export

### DIFF
--- a/apps/Sessions.js
+++ b/apps/Sessions.js
@@ -1,6 +1,6 @@
 import '../src/theme/theme.config'
 import React, { useState } from 'react'
-import { theme } from 'SVTheme'
+import { theme } from 'SVTheme/tapIndex'
 import {
   ReThemeProvider,
   getDefaultTheme,

--- a/configs/rollup.config.js
+++ b/configs/rollup.config.js
@@ -19,7 +19,6 @@ const tapPath = require('app-root-path').path
 const corePath = path.join(`${tapPath}`, `node_modules/keg-core`)
 const isProd = process.env.NODE_ENV === 'production'
 const { ANALYZE } = process.env
-
 const peerExternals = [ 'react', 'react-dom' ]
 
 const buildDependencies = [
@@ -170,7 +169,9 @@ export default {
       },
     }),
     cleanup(),
-    isProd && terser(),
+    isProd && terser({
+      mangle: false
+    }),
     bundleSize(),
     ANALYZE && analyze()
   ],

--- a/src/theme/components/button/evfButton.js
+++ b/src/theme/components/button/evfButton.js
@@ -34,7 +34,6 @@ const defaultTextStyle = {
     lineHeight: 18,
     alignSelf: 'center',
     position: 'relative',
-    top: 2,
   },
   $small: {
     fontSize: 15,


### PR DESCRIPTION
**Ticket**: [ZEN-456](https://jira.simpleviewtools.com/browse/ZEN-456)

[Semver-Status] patch

> ### Notes
> * This pr is dependent on two other PR's
>   * [keg-consumer](https://github.com/simpleviewinc/keg-test-consumer/pull/10)
>   * [keg-hub](https://github.com/simpleviewinc/keg-hub/pull/88)
> * Those PRs should be reviewed along with this one
> * There something wrong with how the theme's `tapIndex` file is being imported
>   * This needs to be investigated further at some point
> * I turned off mangling in terser. This should only be a temporary work around
>   * This needs to be investigated further at some point

## Context

* There's some issue with recent changes that were causing the rollup export to fail


## Goal

* Fix the rollup export so it can be consumed by an external app 

## Updates

* `apps/Sessions.js`
  * There something wrong with how the theme's `tapIndex` file is being imported
  * To work around it, I updated it to import the `tapIndex` directly
  * It's having issues with import from __kegTheme in keg-core
      * Only happens in rollup
* `configs/rollup.config.js`
  * Updated terser to not mangle the output
    * This is causing errors when consumed by external apps
    * The downside is, not mangling the output **adds an extra 20kb** to the final build
* `src/theme/components/button/evfButton.js`
  * Removed 2px from top for buttons
  * This was causing button text to not be properly centered

## Testing

* Run the tests from [this keg-consumer PR](https://github.com/simpleviewinc/keg-test-consumer/pull/10)
  * All changes in this repo, are used within the PR's testing steps