### PR TITLE
Zen 458 group booking disable

### DIFF
--- a/src/components/button/bookingButton.js
+++ b/src/components/button/bookingButton.js
@@ -115,7 +115,7 @@ export const BookingButton = props => {
   const { session } = props
   const bookingModel = useBookingState(session)
   const selectSessionCb = useSelectSession(session, bookingModel)
-  // console.log(bookingModel, `${session.identifier}`)
+
   const pendingStyles = useStyle('button.bookingButton.pending')
 
   return (

--- a/src/components/button/bookingButton.js
+++ b/src/components/button/bookingButton.js
@@ -115,7 +115,7 @@ export const BookingButton = props => {
   const { session } = props
   const bookingModel = useBookingState(session)
   const selectSessionCb = useSelectSession(session, bookingModel)
-
+  // console.log(bookingModel, `${session.identifier}`)
   const pendingStyles = useStyle('button.bookingButton.pending')
 
   return (

--- a/src/mocks/eventsforce/bookingStates/conflict.js
+++ b/src/mocks/eventsforce/bookingStates/conflict.js
@@ -3,9 +3,6 @@ import testData from '../testData'
 const sessions = (isUnlimited = false) => [
   {
     allowBooking: true,
-    // Custom identifier to flag that booking has been stopped for that session
-    // Will need to update when Events-Force gives us the real value
-    // bookingStopped: true,
     identifier: '1',
     name: `state - TIME CONFLICT - ${isUnlimited ? 'UNLIMITED' : 'LIMITED'} A`,
     dayNumber: 1,
@@ -28,9 +25,6 @@ const sessions = (isUnlimited = false) => [
   },
   {
     allowBooking: true,
-    // Custom identifier to flag that booking has been stopped for that session
-    // Will need to update when Events-Force gives us the real value
-    // bookingStopped: true,
     identifier: '2',
     name: `state - TIME CONFLICT - ${isUnlimited ? 'UNLIMITED' : 'LIMITED'} B`,
     dayNumber: 1,

--- a/src/mocks/eventsforce/bookingStates/conflict.js
+++ b/src/mocks/eventsforce/bookingStates/conflict.js
@@ -89,6 +89,10 @@ export const conflict = {
       ...conflictTestData,
       sessions: sessions(),
     },
+    unlimited: {
+      ...conflictTestData,
+      sessions: sessions(true),
+    },
   },
   group: {
     limited: {

--- a/src/mocks/eventsforce/bookingStates/conflict.js
+++ b/src/mocks/eventsforce/bookingStates/conflict.js
@@ -1,59 +1,60 @@
 import testData from '../testData'
 
+const sessions = (isUnlimited = false) => [
+  {
+    allowBooking: true,
+    // Custom identifier to flag that booking has been stopped for that session
+    // Will need to update when Events-Force gives us the real value
+    // bookingStopped: true,
+    identifier: '1',
+    name: `state - TIME CONFLICT - ${isUnlimited ? 'UNLIMITED' : 'LIMITED'} A`,
+    dayNumber: 1,
+    startDateTimeLocal: '2020-08-03 09:00:00',
+    endDateTimeLocal: '2020-08-03 13:30:00',
+    presenterIdentifiers: [ '1', '2' ],
+    labelIdentifiers: [ '1', '2' ],
+    locationIdentifier: '1',
+    liveVideoUrl: 'https://us02web.zoom.us/j/1234',
+    recordedVideoUrl: 'https://www.youtube.com/watch?v=21X5lGlDOfg',
+    restrictToAttendeeCategories: [],
+    capacity: {
+      isUnlimited,
+      remainingPlaces: 5,
+    },
+    price: {
+      currency: 'USD',
+      amount: 923.0,
+    },
+  },
+  {
+    allowBooking: true,
+    // Custom identifier to flag that booking has been stopped for that session
+    // Will need to update when Events-Force gives us the real value
+    // bookingStopped: true,
+    identifier: '2',
+    name: `state - TIME CONFLICT - ${isUnlimited ? 'UNLIMITED' : 'LIMITED'} B`,
+    dayNumber: 1,
+    startDateTimeLocal: '2020-08-03 09:00:00',
+    endDateTimeLocal: '2020-08-03 13:30:00',
+    presenterIdentifiers: [ '1', '2' ],
+    labelIdentifiers: [ '1', '2' ],
+    locationIdentifier: '1',
+    liveVideoUrl: 'https://us02web.zoom.us/j/1234',
+    recordedVideoUrl: 'https://www.youtube.com/watch?v=21X5lGlDOfg',
+    restrictToAttendeeCategories: [],
+    capacity: {
+      isUnlimited,
+      remainingPlaces: 5,
+    },
+    price: {
+      currency: 'USD',
+      amount: 923.0,
+    },
+  },
+]
+
 const conflictTestData = {
   ...testData,
-  sessions: [
-    {
-      allowBooking: true,
-      // Custom identifier to flag that booking has been stopped for that session
-      // Will need to update when Events-Force gives us the real value
-      // bookingStopped: true,
-      identifier: '1',
-      name: 'state - TIME CONFLICT - LIMITED A',
-      dayNumber: 1,
-      startDateTimeLocal: '2020-08-03 09:00:00',
-      endDateTimeLocal: '2020-08-03 13:30:00',
-      presenterIdentifiers: [ '1', '2' ],
-      labelIdentifiers: [ '1', '2' ],
-      locationIdentifier: '1',
-      liveVideoUrl: 'https://us02web.zoom.us/j/1234',
-      recordedVideoUrl: 'https://www.youtube.com/watch?v=21X5lGlDOfg',
-      restrictToAttendeeCategories: [],
-      capacity: {
-        isUnlimited: false,
-        remainingPlaces: 5,
-      },
-      price: {
-        currency: 'USD',
-        amount: 923.0,
-      },
-    },
-    {
-      allowBooking: true,
-      // Custom identifier to flag that booking has been stopped for that session
-      // Will need to update when Events-Force gives us the real value
-      // bookingStopped: true,
-      identifier: '2',
-      name: 'state - TIME CONFLICT - LIMITED B',
-      dayNumber: 1,
-      startDateTimeLocal: '2020-08-03 09:00:00',
-      endDateTimeLocal: '2020-08-03 13:30:00',
-      presenterIdentifiers: [ '1', '2' ],
-      labelIdentifiers: [ '1', '2' ],
-      locationIdentifier: '1',
-      liveVideoUrl: 'https://us02web.zoom.us/j/1234',
-      recordedVideoUrl: 'https://www.youtube.com/watch?v=21X5lGlDOfg',
-      restrictToAttendeeCategories: [],
-      capacity: {
-        isUnlimited: false,
-        remainingPlaces: 5,
-      },
-      price: {
-        currency: 'USD',
-        amount: 923.0,
-      },
-    },
-  ],
   attendees: [
     {
       bookedTicketIdentifier: '1',
@@ -65,23 +66,40 @@ const conflictTestData = {
   ],
 }
 
+const extraAttendees = [
+  {
+    bookedTicketIdentifier: '2',
+    name: 'Mr James',
+    attendeeCategoryIdentifier: '1',
+    bookedDays: [1],
+    bookedSessions: [],
+  },
+  {
+    bookedTicketIdentifier: '3',
+    name: 'Mr Foo Bar',
+    attendeeCategoryIdentifier: '2',
+    bookedDays: [1],
+    bookedSessions: [],
+  },
+]
+
 export const conflict = {
   single: {
-    limited: conflictTestData,
+    limited: {
+      ...conflictTestData,
+      sessions: sessions(),
+    },
   },
   group: {
     limited: {
       ...conflictTestData,
-      attendees: [
-        ...conflictTestData.attendees,
-        {
-          bookedTicketIdentifier: '2',
-          name: 'Mr James',
-          attendeeCategoryIdentifier: '1',
-          bookedDays: [],
-          bookedSessions: [],
-        },
-      ],
+      attendees: [ ...conflictTestData.attendees, ...extraAttendees ],
+      sessions: sessions(),
+    },
+    unlimited: {
+      ...conflictTestData,
+      attendees: [ ...conflictTestData.attendees, ...extraAttendees ],
+      sessions: sessions(true),
     },
   },
 }

--- a/src/utils/models/sessions/__tests__/getDisabled.js
+++ b/src/utils/models/sessions/__tests__/getDisabled.js
@@ -31,7 +31,7 @@ describe('getDisabled', () => {
       expect(getDisabled(props)).toBe(true)
     })
 
-    it('Should return FALSE if remainingPlaces && waitingListAvailable exists', () => {
+    it('Should return FALSE if bookableCount DNE && (remainingPlaces OR waitingListAvailable exists)', () => {
       const props = {
         session: {
           allowBooking: true,
@@ -41,7 +41,25 @@ describe('getDisabled', () => {
           },
         },
       }
+      const withRemainingPlaces = {
+        session: {
+          ...props.session,
+          capacity: {
+            remainingPlaces: 5,
+          },
+        },
+      }
+      const withWaitingList = {
+        session: {
+          ...props.session,
+          capacity: {
+            isWaitingListAvailable: true,
+          },
+        },
+      }
       expect(getDisabled(props)).toBe(false)
+      expect(getDisabled(withRemainingPlaces)).toBe(false)
+      expect(getDisabled(withWaitingList)).toBe(false)
     })
   })
 

--- a/src/utils/models/sessions/bookingStateFactory.js
+++ b/src/utils/models/sessions/bookingStateFactory.js
@@ -2,6 +2,7 @@ import { EVFIcons } from 'SVIcons'
 import { Values } from 'SVConstants'
 import { reduceObj, exists } from '@keg-hub/jsutils'
 import { BookingState } from 'SVModels/session/bookingState'
+import { getDisabled } from './getDisabled'
 
 const { BookingCheck, Digit } = EVFIcons
 const {
@@ -52,66 +53,6 @@ const getStateIcon = (bookingMode, value, bookingList, waitingList) => {
   return BOOKING_STATES_WITH_ICON[value]
     ? { displayAmount, icon: bookingMode === 'single' ? BookingCheck : Digit }
     : {}
-}
-
-/**
- * TODO: Sync with events force to have them pass an option for bookingStopped
- * Will need to update this method to pull that option based on how its passed in
- */
-/**
- * Checks if the booking display should be disabled from interaction
- * @param {import('SVModels/session').Session} props.session
- *
- * @returns {boolean} - If booking changes have been stopped for this session
- */
-const getBookingStopped = session => {
-  return session.bookingStopped
-}
-
-/**
- * Checks if the booking display should be disabled from interaction
- * @param {Object} props
- * @param {import('SVModels/session').Session} props.session
- * @param {import('SVModels/PendingSession').PendingSession} props.pendingSession - currently pending session, if there is one
- * @param {Array} props.bookableCount - Attendees that can book the current session
- * @param {string} props.bookingMode - Current mode of booking for the session (single|group)
- * @param {Object} props.timeConflicts - Key value pairs of attendees booked in conflicting sessions
- * @param {Object} state
- *
- * @returns {boolean} - If the display interaction should be disabled
- */
-const getDisabled = (
-  { session, pendingSession, bookableCount, bookingMode, timeConflicts },
-  state
-) => {
-  // if there is a different session awaiting the booking request result, all others are disabled
-  if (
-    pendingSession?.identifier &&
-    pendingSession.identifier !== session.identifier
-  )
-    return true
-
-  // If state is select, and in single booking mode and there's a time conflict
-  // Then the booking state should be disabled
-  if (
-    state === SESSION_BOOKING_STATES.SELECT &&
-    bookingMode === 'single' &&
-    timeConflicts
-  )
-    return true
-
-  const { capacity, allowBooking } = session
-
-  const bookingStopped = getBookingStopped(session)
-  const noCapacity =
-    !bookableCount ||
-    (!capacity?.remainingPlaces && !capacity?.isWaitingListAvailable)
-
-  return capacity?.isUnlimited
-    ? false
-    : !allowBooking || bookingStopped || noCapacity
-        ? true
-        : false
 }
 
 /**

--- a/src/utils/models/sessions/getDisabled.js
+++ b/src/utils/models/sessions/getDisabled.js
@@ -52,9 +52,13 @@ export const getDisabled = (
   const bookingStopped = getBookingStopped(session)
 
   // no capacity if bookableCount === 0 OR waitingList with spaces is not available
-  const noCapacity = exists(bookableCount)
-    ? !isPositive(bookableCount)
-    : !(capacity?.remainingPlaces && capacity?.isWaitingListAvailable)
+  const noCapacity =
+    (exists(bookableCount) && !isPositive(bookableCount)) ||
+    !(
+      capacity?.remainingPlaces ||
+      capacity?.isWaitingListAvailable ||
+      capacity?.isUnlimited
+    )
 
   // disable if there's no space left or if everyone in the group is booked on a conflicting session
   return !allowBooking || bookingStopped || noCapacity ? true : false

--- a/src/utils/models/sessions/getDisabled.js
+++ b/src/utils/models/sessions/getDisabled.js
@@ -1,0 +1,61 @@
+import { Values } from 'SVConstants'
+import { isPositive, exists } from '@keg-hub/jsutils'
+const { SESSION_BOOKING_STATES } = Values
+
+/**
+ * TODO: Sync with events force to have them pass an option for bookingStopped
+ * Will need to update this method to pull that option based on how its passed in
+ */
+/**
+ * Checks if the booking display should be disabled from interaction
+ * @param {import('SVModels/session').Session} props.session
+ *
+ * @returns {boolean} - If booking changes have been stopped for this session
+ */
+const getBookingStopped = session => {
+  return session.bookingStopped
+}
+
+/**
+ * Checks if the booking display should be disabled from interaction
+ * @param {Object} props
+ * @param {import('SVModels/session').Session} props.session
+ * @param {import('SVModels/PendingSession').PendingSession} props.pendingSession - currently pending session, if there is one
+ * @param {Number} props.bookableCount - Attendees that can book the current session
+ * @param {string} props.bookingMode - Current mode of booking for the session (single|group)
+ * @param {Object} props.timeConflicts - Key value pairs of attendees booked in conflicting sessions. { ${attendeeId}: ${sessionId} }
+ * @param {Object} state
+ *
+ * @returns {boolean} - If the display interaction should be disabled
+ */
+export const getDisabled = (
+  { session, pendingSession, bookableCount, bookingMode, timeConflicts },
+  state
+) => {
+  // if there is a different session awaiting the booking request result, all others are disabled
+  if (
+    pendingSession?.identifier &&
+    pendingSession.identifier !== session.identifier
+  )
+    return true
+  // If state is select, and in single booking mode and there's a time conflict
+  // Then the booking state should be disabled
+  if (
+    state === SESSION_BOOKING_STATES.SELECT &&
+    bookingMode === 'single' &&
+    timeConflicts
+  )
+    return true
+
+  const { capacity, allowBooking } = session
+
+  const bookingStopped = getBookingStopped(session)
+
+  // no capacity if bookableCount === 0 OR waitingList with spaces is not available
+  const noCapacity = exists(bookableCount)
+    ? !isPositive(bookableCount)
+    : !(capacity?.remainingPlaces && capacity?.isWaitingListAvailable)
+
+  // disable if there's no space left or if everyone in the group is booked on a conflicting session
+  return !allowBooking || bookingStopped || noCapacity ? true : false
+}

--- a/src/utils/models/sessions/getDisabled.js
+++ b/src/utils/models/sessions/getDisabled.js
@@ -3,20 +3,6 @@ import { isPositive, exists } from '@keg-hub/jsutils'
 const { SESSION_BOOKING_STATES } = Values
 
 /**
- * TODO: Sync with events force to have them pass an option for bookingStopped
- * Will need to update this method to pull that option based on how its passed in
- */
-/**
- * Checks if the booking display should be disabled from interaction
- * @param {import('SVModels/session').Session} props.session
- *
- * @returns {boolean} - If booking changes have been stopped for this session
- */
-const getBookingStopped = session => {
-  return session.bookingStopped
-}
-
-/**
  * Checks if the booking display should be disabled from interaction
  * @param {Object} props
  * @param {import('SVModels/session').Session} props.session
@@ -49,8 +35,6 @@ export const getDisabled = (
 
   const { capacity, allowBooking } = session
 
-  const bookingStopped = getBookingStopped(session)
-
   // no capacity if bookableCount === 0 OR waitingList with spaces is not available
   const noCapacity =
     (exists(bookableCount) && !isPositive(bookableCount)) ||
@@ -61,5 +45,5 @@ export const getDisabled = (
     )
 
   // disable if there's no space left or if everyone in the group is booked on a conflicting session
-  return !allowBooking || bookingStopped || noCapacity ? true : false
+  return !allowBooking || noCapacity ? true : false
 }


### PR DESCRIPTION
**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-458)

## Context

* in group booking mode, when every single person is booked to a session. Any adjacent session should have its booking button disabled. Just like the single booking mode

## Goal

* group booking conflict - unlimited is an edge case that was missed
* exctract out `getDisabled` method so it can be unit tested

## Updates

* `src/mocks/eventsforce/bookingStates/conflict.js`
    * updated conflict test data
* `src/utils/models/sessions/bookingStateFactory.js`
    * extracted `getDisabled` to its own file
* `src/utils/models/sessions/getDisabled.js`
    * the extracted method from `bookingStateFactory`
    *  minor adjust so it will disable when capacity is unlimited && conflict exists
## Testing
### Unit tests
* run `keg evf pack run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:zen-458-group-booking-disable command=test`
* verify all test passes

* run `keg evf pack run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:zen-458-group-booking-disable`
* navigate to http://evf-zen-458-group-booking-disable.local.kegdev.xyz/

### Single booking conflicts
* verify this still works the same as before
* update the JSON booking data to `conflict-single-limited`
* verify if you book a session that has the same day and time as another session, that session booking btn is disabled
* repeat with JSON booking data `conflict-single-unlimited`

### Group booking conflicts
on these booking data: (`conflict-group-limited` && `conflict-group-unlimited`)
* verify if you book all the possible attendees in the group to Session A. Session B's booking button  will be disabled. and vice versa
    * [image](https://user-images.githubusercontent.com/3317835/102927484-53df0b00-4454-11eb-86d6-b95122640e31.png)

### Spot Check
* Modify the JSON data for other disabled button variation (single && group booking)
    * `fully booked` state should disable the button
    * modifying `session.capacity.remainingPlaces === 0` && `session.capacity.isWaitingListAvailable === false` should disable the button