### PR TITLE
feat: Add container folder

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,81 @@
+# Allows overwriting where the base image is pulled from
+# Must come before the FROM directive
+ARG KEG_NODE_VERSION
+ARG GIT_STAGE_IMAGE_FROM=node:$KEG_NODE_VERSION
+ARG KEG_IMAGE_FROM=keg-base:development
+FROM $KEG_IMAGE_FROM as builder
+
+WORKDIR /
+
+# These args are expected to be set as --build-arg
+# Which Allow them to be used durring the build
+ARG GIT_APP_URL=INITIAL
+
+# Should we use the local copy of the tap repo when building
+ARG KEG_COPY_LOCAL
+
+# Path of the app within the docker container
+ARG DOC_APP_PATH=/keg/tap
+
+# Copy over the package.json, and yarn.lock files
+COPY . /keg-temp/
+
+# Update the build steps git config to include the key
+# Pull down the tap locally if a git tap url exists
+# Otherwise copy over the local version from keg-temp
+RUN if [ -z "$KEG_COPY_LOCAL" ] && [ "$GIT_APP_URL" != "INITIAL" ]; then \
+      git clone $GIT_APP_URL $DOC_APP_PATH; \
+    else \
+      cp -R /keg-temp/ $DOC_APP_PATH; \
+    fi; \
+    rm -rf /keg-temp
+
+# Install the dependecies with yarn setup, then remove the .npmrc
+RUN cd $DOC_APP_PATH; \
+    yarn install; \
+    cd $DOC_APP_PATH/node_modules/keg-core; \
+    yarn install; \
+    cd $DOC_APP_PATH; \
+    yarn cache clean
+
+# ------- New Build Stage ------- #
+
+# Use a multi stage build for security
+FROM $GIT_STAGE_IMAGE_FROM as gitBuilder
+WORKDIR /
+
+# Path of the app within the docker container
+ARG DOC_APP_PATH=/keg/tap
+
+# Get the ip of docker-machine from the ARG, so we can set it as an ENV
+ARG KEG_DOCKER_IP
+
+# Used by react native builder to set the ip address, other wise 
+# Will use the ip address of the docker container.
+ENV REACT_NATIVE_PACKAGER_HOSTNAME $KEG_DOCKER_IP
+
+# Install git for the new stage
+RUN apk add --no-cache git bash sudo; \
+    echo fs.inotify.max_user_watches=1048576 | sudo tee -a /etc/sysctl.conf; \
+    sudo sysctl -p; \
+    rm -rf /var/cache/apk/*; \
+    /bin/sed -i '1s|.*|root:x:0:0:root:/root:/bin/bash|g' /etc/passwd
+
+# Copy over the globally installed modules from above
+COPY --from=builder /usr/local/share/.config/yarn /usr/local/share/.config/yarn
+# Add yarn's global bin to PATH
+ENV PATH=$PATH:/usr/local/share/.config/yarn/global/node_modules/.bin
+
+# Copy over the cloned app
+COPY --from=builder $DOC_APP_PATH $DOC_APP_PATH
+
+# Expose container ports
+EXPOSE 19006
+
+# Set the current directory to tap repo
+WORKDIR /$DOC_APP_PATH
+
+SHELL [ "/bin/bash" ]
+
+# Run the start script
+CMD [ "/bin/bash", "container/run.sh" ]

--- a/container/docker-compose.yml
+++ b/container/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3.8"
+services:
+  evf:
+    privileged: true
+    build:
+      context: ${KEG_CONTEXT_PATH}
+      dockerfile: ${KEG_DOCKER_FILE}
+      args:
+        - DOC_APP_PATH
+        - DOC_CORE_PATH
+        - DOC_COMPONENTS_PATH
+        - DOC_JSUTILS_PATH
+        - DOC_RESOLVER_PATH
+        - DOC_RETHEME_PATH
+        - EXPO_DEVTOOLS_LISTEN_ADDRESS
+        - GIT_APP_URL
+        - KEG_DOCKER_IP
+        - KEG_IMAGE_FROM
+        - KEG_EXEC_CMD
+        - KEG_NODE_VERSION
+        - KEG_NM_INSTALL
+        - NODE_ENV
+        - TAP
+    environment:
+      - CHOKIDAR_USEPOLLING
+      - DOC_APP_PATH
+      - DOC_CORE_PATH
+      - DOC_COMPONENTS_PATH
+      - DOC_JSUTILS_PATH
+      - DOC_RESOLVER_PATH
+      - DOC_RETHEME_PATH
+      - EXPO_DEVTOOLS_LISTEN_ADDRESS
+      - GIT_APP_URL
+      - KEG_DOCKER_IP
+      - KEG_EXEC_CMD
+      - KEG_DOCKER_EXEC
+      - KEG_NM_INSTALL
+      - KEG_NODE_VERSION
+      - NODE_ENV
+      - TAP

--- a/container/mutagen.yml
+++ b/container/mutagen.yml
@@ -1,0 +1,124 @@
+sync:
+  tap:
+    alpha: "/keg/tap"
+    beta: "docker://tap/keg/tap"
+    mode: "one-way-replica"
+    ignore:
+      vcs: true
+      paths:
+        - "node_modules"
+        - "/core/base/assets/*"
+        - "/.*"
+        - "!/.storybook"
+        - "!/.npmrc"
+        - "*.lock"
+        - "*.md"
+        - "/temp"
+        - "/web-build"
+        - "/reports"
+        - "/build"
+        - "/docs"
+actions:
+  resolver:
+    install:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/tap-resolver
+      privileged: true
+      cmds:
+        - yarn install
+    att:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/tap-resolver
+      privileged: true
+      cmds:
+        - bash
+  core:
+    install:
+      location: /keg/tap/node_modules/keg-core
+      privileged: true
+      cmds:
+        - yarn install
+    att:
+      location: /keg/tap/node_modules/keg-core
+      privileged: true
+      cmds:
+        - bash
+  jsutils:
+    install:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
+      privileged: true
+      cmds:
+        - yarn install
+    build:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
+      privileged: true
+      cmds:
+        - yarn build
+    start:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
+      privileged: true
+      cmds:
+        - yarn dev
+    att:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
+      privileged: true
+      cmds:
+        - bash
+  retheme:
+    install:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme
+      privileged: true
+      cmds:
+        - yarn install
+    build:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme
+      privileged: true
+      cmds:
+        - yarn build
+    start:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme
+      privileged: true
+      detach: true
+      cmds:
+        - yarn dev
+    run:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme
+      privileged: true
+      cmds:
+        - yarn dev
+    att:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme
+      privileged: true
+      cmds:
+        - bash
+  components:
+    install:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
+      privileged: true
+      cmds:
+        - yarn install
+    build:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
+      privileged: true
+      cmds:
+        - yarn build
+    start:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
+      privileged: true
+      detach: true
+      cmds:
+        - yarn dev
+    run:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
+      privileged: true
+      cmds:
+        - yarn dev
+    att:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
+      privileged: true
+      cmds:
+        - bash
+  tap:
+    start:
+      location: /keg/tap
+      privileged: true
+      cmds:
+        - yarn tap:start

--- a/container/mutagen.yml
+++ b/container/mutagen.yml
@@ -1,5 +1,5 @@
 sync:
-  tap:
+  evf:
     alpha: "/keg/tap"
     beta: "docker://tap/keg/tap"
     mode: "one-way-replica"

--- a/container/run.sh
+++ b/container/run.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env
+
+TAP_PATH=/keg/tap
+
+if [[ "$DOC_APP_PATH" ]]; then
+  TAP_PATH="$DOC_APP_PATH"
+fi
+
+keg_message(){
+  echo $"[ KEG-CLI ] $1" >&2
+  return
+}
+
+# Runs yarn install at run time
+# Use when adding extra node_modules to keg-core without rebuilding
+keg_run_tap_yarn_setup(){
+
+  # Check if $KEG_NM_INSTALL exist, if it doesn't, then return
+  if [[ -z "$KEG_NM_INSTALL" ]]; then
+    return
+  fi
+
+  if [[ "$KEG_NM_INSTALL" != "core" ]]; then
+    # Navigate to the cached directory, and run the yarn install here
+    cd $TAP_PATH
+    keg_message "Running yarn setup for tap..."
+    yarn install
+  fi
+  
+  if [[ "$KEG_NM_INSTALL" ]]; then
+    if [[ -d "$TAP_PATH/node_modules/keg-core" ]]; then
+      keg_message "Running yarn install for keg-core..."
+      cd $TAP_PATH/node_modules/keg-core
+      yarn install
+    fi
+  fi
+
+}
+
+# Runs a Tap
+keg_run_the_tap(){
+
+  cd $TAP_PATH
+
+  if [[ -z "$KEG_EXEC_CMD" ]]; then
+    KEG_EXEC_CMD="tap:start"
+  fi
+
+  keg_message "Running command 'yarn $KEG_EXEC_CMD'"
+  yarn $KEG_EXEC_CMD
+
+}
+
+# If the no KEG_DOCKER_EXEC env is set, just sleep forever
+# This is to keep our container running forever
+if [[ -z "$KEG_DOCKER_EXEC" ]]; then
+  tail -f /dev/null
+  exit 0
+
+else
+
+  # Run yarn setup for any extra node_modules to be installed
+  keg_run_tap_yarn_setup
+
+  # Start the keg core instance
+  keg_run_the_tap
+fi

--- a/container/values.yml
+++ b/container/values.yml
@@ -1,0 +1,77 @@
+
+start: /bin/bash /keg/keg-cli/containers/tap/run.sh
+env:
+  # --- LOCAL ENV CONTEXT --- #
+  COMPONENTS_PATH: "{{ cli.paths.components }}"
+  RETHEME_PATH: "{{ cli.taps.retheme.path }}"
+  RESOLVER_PATH: "{{ cli.paths.resolver }}"
+  CLI_PATH: "{{ cli.paths.cli }}"
+  
+  # --- TAP ENV CONTEXT --- #
+
+  # Docker / Docker Compose paths
+  KEG_DOCKER_FILE: "{{ cli.paths.containers }}/tap/Dockerfile"
+  KEG_VALUES_FILE: "{{ cli.paths.containers }}/tap/values.yml"
+  KEG_MUTAGEN_PATH: "{{ cli.paths.containers }}/tap/mutagen.yml"
+
+  # The default docker-compose file path
+  KEG_COMPOSE_DEFAULT: "{{ cli.paths.containers }}/tap/docker-compose.yml"
+  # Can also define other an override compose files
+  # Other compose files can loaded by setting an ENVS as follows:
+    # KEG_COMPOSE_REPO="/path/to/override.yml"
+    # KEG_COMPOSE_TAP_<ENV>: "/path/to/override.yml"
+    # KEG_COMPOSE_<ENV>: "/path/to/override.yml"
+
+  # The KEG_CONTEXT_PATH env should be the location of the tap being run
+  # So it should NOT be set inside the .env file
+  KEG_CONTEXT_PATH: INITIAL
+
+  # --- DOCKER ENV CONTEXT --- #
+
+  # Default location of the tap in the docker container
+  DOC_APP_PATH: /keg/tap
+
+  # Defines the location in a docker container for a dependency
+  # This allows mutagen to know where to sync the local version of the dependency
+  DOC_CORE_PATH: /keg/tap/node_modules/keg-core
+  DOC_COMPONENTS_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
+  DOC_RETHEME_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme
+  DOC_RESOLVER_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/tap-resolver
+  DOC_JSUTILS_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/jsutils
+
+  # Allow access to expo dev tools within the docker container
+  EXPO_DEVTOOLS_LISTEN_ADDRESS: 0.0.0.0
+  KEG_EXEC_CMD: tap:start
+
+  # --- KEG-PROXY ENVs --- #
+
+  # KEG_PROXY_HOST: custom-host.local.kegdev.xyz
+    # To override the host header used by the proxy to route traffic to this container
+    # add KEG_PROXY_HOST env and set it's value to the what the host header should be
+    # the default is <container-context>-<git-branch-name>.<KEG_PROXY_HOST>
+  
+  # KEG_DOCKER_NETWORK: custom-docker-network
+    # To override the default docker network used by the proxy to route traffic to this container
+    # There should be no reason to need to overwrite this, but you can if you want
+    # add KEG_PROXY_HOST env and set it's value to the what network should be used
+    # the default is 'keg-hub-net'
+
+  # KEG_PROXY_PORT - 80
+    # If not set, then port 80 will be used by default
+    # Port the proxy will route traffic to within the container
+    # This should be the port the application expects to receive traffic on
+    # This port should not be ( You can still do these things, but it's better not to )
+    #   * Exposed publicly on the container
+    #   * Bound to the host machine
+  KEG_PROXY_PORT: 19006
+
+  # --- GENERAL CONTEXT ENVs --- #
+
+  # Image Build information
+  IMAGE: evf
+  VERSION: "0.0.1"
+  CONTAINER_NAME: evf
+  CHOKIDAR_USEPOLLING: 1
+
+  # Git tap url in github
+  GIT_APP_URL: INITIAL


### PR DESCRIPTION
## Context

* The keg-cli can use a container folder for taps as injected apps
* This decouples the tap from the keg-cli, while at the same time still allows it to be used

## Goal

* Add a container folder
* ensure it still build and runs as expected

## Updates

* Copied the `containers/tap` folder from the Keg-CLI into the root dir
* Made some minor path updates for the container folder

## Testing

**Test 1**
* Pull this PR => `keg evf && keg pr 113`
* Remove any existing `tap || evf` docker images. This ensures a fresh build
* Run the cmd `keg evf start` - This should build and start the events-force tap, using the container folder
  * Ensure everything runs as expected

**Test 2**
*  Next run the command `docker inspect evf`
  * This should print out a bunch of data about the events-force docker image 
  * In the output, search for the label `com.docker.compose.project.config_files`
   * This label shows the docker-compose files used to build the image 
   * The value of that label should include `keg-hub/taps/tap-events-force/container/docker-compose.yml` in it's path
     * Looks like this => http://snpy.in/kprqOM
   * **NOTES**  Other labels may still be pointing to the `keg-cli/containers/tap` folder.  Those can be ignored, they are not used at this time
  
