### PR TITLE
ZEN-541 Day Name Text

### DIFF
--- a/src/components/sessionsHeader/sessionsHeader.js
+++ b/src/components/sessionsHeader/sessionsHeader.js
@@ -1,9 +1,7 @@
 import { EVFIcons } from 'SVIcons'
 import { Values } from 'SVConstants'
-import { format, parseISO } from 'date-fns'
 import { useCreateModal } from 'SVHooks/modal'
 import React, { useCallback, useMemo } from 'react'
-import { useAgenda } from 'SVHooks/models/useAgenda'
 import { DayToggle } from 'SVComponents/dates/dayToggle'
 import { useStoreItems } from 'SVHooks/store/useStoreItems'
 import { ItemHeader, Button, View } from '@keg-hub/keg-components'
@@ -126,43 +124,49 @@ const ItemHeaderRight = ({ styles, onClick }) => {
  * @param {Function} props.onDayChange - function for handling day changes in the day toggle
  * @param {number} props.currentDay - The active day of the session
  * @param {Object} props.agenda - Metadata for the current days sessions
- * @param {string} props.dayText - The day number and name for the active day based on viewport size
+ * @param {string} props.dayText - override for dayName
  */
-export const SessionsHeader = React.memo(({ agenda, currentDay, dayText, onDayChange, labels }) => {
-  const { agendaLength, isLatestDay, isFirstDay } = agenda
-  const theme = useTheme()
-  const styles = theme.get('sessions')
+export const SessionsHeader = React.memo(
+  ({ agenda, currentDay, dayText, onDayChange, labels }) => {
+    const { agendaLength, isLatestDay, isFirstDay, dayName = dayText } = agenda
+    const theme = useTheme()
+    const styles = theme.get('sessions')
 
-  const increment = useCallback(() => incrementDay(onDayChange), [onDayChange])
-  const decrement = useCallback(() => decrementDay(onDayChange), [onDayChange])
-  const headerStyles = styles.content?.header
-  const displayFilterModal = useCreateModal(MODAL_TYPES.FILTER, { labels })
+    const increment = useCallback(() => incrementDay(onDayChange), [
+      onDayChange,
+    ])
+    const decrement = useCallback(() => decrementDay(onDayChange), [
+      onDayChange,
+    ])
+    const headerStyles = styles.content?.header
+    const displayFilterModal = useCreateModal(MODAL_TYPES.FILTER, { labels })
 
-  return (
-    <View
-      style={headerStyles?.container}
-      className='ef-sessions-header-container'
-    >
-      <ItemHeader
-        styles={headerStyles}
-        className='ef-sessions-header'
-        CenterComponent={
-          <DayToggle
-            dayText={dayText}
-            dayNumber={currentDay}
-            disableDecrement={isFirstDay}
-            disableIncrement={isLatestDay || !agendaLength}
-            onDecrement={decrement}
-            onIncrement={increment}
-          />
-        }
-        RightComponent={
-          <ItemHeaderRight
-            styles={headerStyles?.content?.right?.content}
-            onClick={displayFilterModal}
-          />
-        }
-      />
-    </View>
-  )
-})
+    return (
+      <View
+        style={headerStyles?.container}
+        className='ef-sessions-header-container'
+      >
+        <ItemHeader
+          styles={headerStyles}
+          className='ef-sessions-header'
+          CenterComponent={
+            <DayToggle
+              dayText={dayName}
+              dayNumber={currentDay}
+              disableDecrement={isFirstDay}
+              disableIncrement={isLatestDay || !agendaLength}
+              onDecrement={decrement}
+              onIncrement={increment}
+            />
+          }
+          RightComponent={
+            <ItemHeaderRight
+              styles={headerStyles?.content?.right?.content}
+              onClick={displayFilterModal}
+            />
+          }
+        />
+      </View>
+    )
+  }
+)

--- a/src/components/sessionsList/sessionsList.js
+++ b/src/components/sessionsList/sessionsList.js
@@ -1,7 +1,7 @@
 import { format, parseISO } from 'date-fns'
 import { isMobileSize } from 'SVUtils/theme'
 import { useTheme } from '@keg-hub/re-theme'
-import { reduceObj, noPropArr } from '@keg-hub/jsutils'
+import { reduceObj } from '@keg-hub/jsutils'
 import React, { useMemo, useCallback } from 'react'
 import { SessionsDivider } from './sessionsDivider'
 import { useAgenda } from 'SVHooks/models/useAgenda'
@@ -116,21 +116,6 @@ const useOnScrollChange = (sections, currentDay, onDayChange) => {
 }
 
 /**
- * Gets the text to display as the day name
- * @param {Array} agendaDays
- * @param {Number} currentDay
- *
- * @returns {string}
- */
-const getDayName = (agendaDays = noPropArr, currentDay) => {
-  if (agendaDays.length === 0 || !currentDay) return ''
-  const currentAgendaDay = agendaDays.find(
-    agendaDay => agendaDay?.dayNumber === currentDay
-  )
-  return (currentAgendaDay && currentAgendaDay?.dayName) || ''
-}
-
-/**
  * SessionList - Container for all sessions separated by day
  * @param {object} props
  * @param {Array<import('SVModels/label').Label>} props.labels - session labels
@@ -157,7 +142,6 @@ export const SessionsList = props => {
     currentDay,
     onDayChange
   )
-  const dayText = getDayName(agenda?.agendaDays, currentDay)
 
   return (
     <SectionList
@@ -174,7 +158,6 @@ export const SessionsList = props => {
       renderListHeader={({ onSectionChange: onDayChange }) => (
         <SessionsHeader
           agenda={agenda}
-          dayText={dayText}
           currentDay={currentDay}
           labels={itemProps.labels}
           onDayChange={onDayChange}

--- a/src/components/sessionsList/sessionsList.js
+++ b/src/components/sessionsList/sessionsList.js
@@ -1,7 +1,7 @@
 import { format, parseISO } from 'date-fns'
 import { isMobileSize } from 'SVUtils/theme'
 import { useTheme } from '@keg-hub/re-theme'
-import { reduceObj } from '@keg-hub/jsutils'
+import { reduceObj, noPropArr } from '@keg-hub/jsutils'
 import React, { useMemo, useCallback } from 'react'
 import { SessionsDivider } from './sessionsDivider'
 import { useAgenda } from 'SVHooks/models/useAgenda'
@@ -116,6 +116,21 @@ const useOnScrollChange = (sections, currentDay, onDayChange) => {
 }
 
 /**
+ * Gets the text to display as the day name
+ * @param {Array} agendaDays
+ * @param {Number} currentDay
+ *
+ * @returns {string}
+ */
+const getDayName = (agendaDays = noPropArr, currentDay) => {
+  if (agendaDays.length === 0 || !currentDay) return ''
+  const currentAgendaDay = agendaDays.find(
+    agendaDay => agendaDay?.dayNumber === currentDay
+  )
+  return (currentAgendaDay && currentAgendaDay?.dayName) || ''
+}
+
+/**
  * SessionList - Container for all sessions separated by day
  * @param {object} props
  * @param {Array<import('SVModels/label').Label>} props.labels - session labels
@@ -142,6 +157,7 @@ export const SessionsList = props => {
     currentDay,
     onDayChange
   )
+  const dayText = getDayName(agenda?.agendaDays, currentDay)
 
   return (
     <SectionList
@@ -158,7 +174,7 @@ export const SessionsList = props => {
       renderListHeader={({ onSectionChange: onDayChange }) => (
         <SessionsHeader
           agenda={agenda}
-          dayText={dateByDay[currentDay]}
+          dayText={dayText}
           currentDay={currentDay}
           labels={itemProps.labels}
           onDayChange={onDayChange}

--- a/src/components/sessionsList/sessionsList.js
+++ b/src/components/sessionsList/sessionsList.js
@@ -1,7 +1,6 @@
-import { format, parseISO } from 'date-fns'
 import { isMobileSize } from 'SVUtils/theme'
 import { useTheme } from '@keg-hub/re-theme'
-import { reduceObj } from '@keg-hub/jsutils'
+import { reduceObj, noPropArr } from '@keg-hub/jsutils'
 import React, { useMemo, useCallback } from 'react'
 import { SessionsDivider } from './sessionsDivider'
 import { useAgenda } from 'SVHooks/models/useAgenda'
@@ -44,34 +43,13 @@ const useListStyles = () => {
 }
 
 /**
- * Hook to map the day numbers to the day text that's displayed
- * <br/> Get's the correct Day text based on current viewport size
- * @param {Array} agendaDays - Group of days from the current agenda
- * @param {boolean} isMobile - Is the current size of the viewport mobile
- *
- * @returns {Object} - Mapped day numbers to displayed day text
- */
-const useDateTextByDay = (agendaDays, isMobile) => {
-  const dateList = agendaDays.map(day => day.date).join(',')
-  return useMemo(() => {
-    return agendaDays.reduce((mapped, { date, dayNumber }) => {
-      const dayName = date && format(parseISO(date), 'EEEE')
-      mapped[dayNumber] = isMobile
-        ? `Day ${dayNumber} ${dayName}`.trim()
-        : `Day ${dayNumber}`
-
-      return mapped
-    }, {})
-  }, [ dateList, isMobile ])
-}
-
-/**
  * Hook to memoize the sessions for a day, and add a key
  * @param {Array} sessions - group of sessions by day
+ * @param {Array} agendaDays
  *
  * @returns {Array} - memoized sessions in SectionList required format
  */
-const useSessionsSections = (sessions, dateByDay) => {
+const useSessionsSections = (sessions, agendaDays = noPropArr) => {
   return useMemo(() => {
     return reduceObj(
       sessions,
@@ -83,7 +61,9 @@ const useSessionsSections = (sessions, dateByDay) => {
           // Is the last section, if total sections === total sessions minus one
           last: Object.keys(sessions).length - 1 === sections.length,
           // Store the text to displace above each day
-          dayText: dateByDay[dayNum],
+          dayText: agendaDays.find(
+            agendaDay => agendaDay.dayNumber === parseInt(dayNum)
+          )?.dayName,
           data: timeBlocks.map(timeBlock => {
             timeBlock.key = `${dayNum}-${timeBlock.timeBlock}`
             return timeBlock
@@ -94,7 +74,7 @@ const useSessionsSections = (sessions, dateByDay) => {
       },
       []
     )
-  }, [ sessions, dateByDay ])
+  }, [ sessions, agendaDays ])
 }
 
 /**
@@ -135,8 +115,7 @@ export const SessionsList = props => {
   const agenda = useAgenda()
   const styles = useListStyles()
   const isMobile = isMobileSize(theme)
-  const dateByDay = useDateTextByDay(agenda.agendaDays, isMobile)
-  const sections = useSessionsSections(sessions, dateByDay)
+  const sections = useSessionsSections(sessions, agenda?.agendaDays)
   const onScrollSectionChange = useOnScrollChange(
     sections,
     currentDay,

--- a/src/hooks/models/useAgenda.js
+++ b/src/hooks/models/useAgenda.js
@@ -1,5 +1,5 @@
 import { get } from '@keg-hub/jsutils'
-import { getCurrentDay, getLatestDay, isLatestDay } from 'SVUtils'
+import { getCurrentDay, getLatestDay, isLatestDay, getDayName } from 'SVUtils'
 import { useStoreItems } from 'SVHooks/store/useStoreItems'
 
 /**
@@ -17,6 +17,7 @@ export const useAgenda = () => {
   const currentDayNumber = get(agendaSettings, 'activeDayNumber')
   const currentAgendaDay = getCurrentDay(agendaDays, currentDayNumber)
   const latestAgendaDay = getLatestDay(agendaDays)
+  const dayName = getDayName(agendaDays, currentDayNumber)
   const currentDayIsLatest = isLatestDay(currentDayNumber, agendaDays)
   const isFirstDay = currentDayNumber === 1
 
@@ -29,5 +30,6 @@ export const useAgenda = () => {
     isLatestDay: currentDayIsLatest,
     agendaLength: agendaDays?.length ?? 0,
     isFirstDay,
+    dayName,
   }
 }

--- a/src/mocks/eventsforce/testData.js
+++ b/src/mocks/eventsforce/testData.js
@@ -13,15 +13,18 @@ export default {
   agendaDays: [
     {
       dayNumber: 1,
-      date: '2020-07-17',
+      date: '2021-01-29',
+      dayName: 'Day 1 - Introduction day',
     },
     {
       dayNumber: 2,
-      date: '2020-07-18',
+      date: '2021-01-30',
+      dayName: 'Day 2',
     },
     {
       dayNumber: 3,
-      date: '2020-07-19',
+      date: '2021-01-31',
+      dayName: 'Day 3',
     },
   ],
   settings: {

--- a/src/models/agendaDay.js
+++ b/src/models/agendaDay.js
@@ -3,11 +3,12 @@ import { assignDefinedProps } from 'SVUtils/object/assignDefinedProps'
 export class AgendaDay {
   dayNumber = undefined
   date = new Date()
-
+  dayName = ''
   /**
    * AgendaSettings class model
    * @property {number} dayNumber - the day number in the agenda
    * @property {string} date - the date string
+   * @property {string} dayName - label to display
    */
   constructor(params = {}) {
     assignDefinedProps(this, params)

--- a/src/theme/components/dates/dayToggle.js
+++ b/src/theme/components/dates/dayToggle.js
@@ -7,6 +7,7 @@ export const dayToggle = {
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'space-between',
+        maxWidth: '100%',
       },
     },
     $native: {

--- a/src/utils/models/agenda/agendaDays/getDayName.js
+++ b/src/utils/models/agenda/agendaDays/getDayName.js
@@ -1,0 +1,16 @@
+import { noPropArr } from '@keg-hub/jsutils'
+
+/**
+ * Gets the text to display as the day name
+ * @param {Array} agendaDays
+ * @param {Number} currentDay
+ *
+ * @returns {string}
+ */
+export const getDayName = (agendaDays = noPropArr, currentDay) => {
+  if (agendaDays.length === 0 || !currentDay) return ''
+  const currentAgendaDay = agendaDays.find(
+    agendaDay => agendaDay?.dayNumber === currentDay
+  )
+  return (currentAgendaDay && currentAgendaDay?.dayName) || ''
+}

--- a/src/utils/models/agenda/agendaDays/index.js
+++ b/src/utils/models/agenda/agendaDays/index.js
@@ -1,3 +1,4 @@
 export * from './getLatestDay.js'
 export * from './getCurrentDay.js'
 export * from './isLatestDay.js'
+export * from './getDayName'


### PR DESCRIPTION


**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-541)

## Context

* EVF changed the behavior of the dayToggle again. there must be no calculated rendering of the day date. It must come directly from the dayName json value for each day.

## Goal

- add prop dayName to agendaDay
- use agendaDay.dayName as the label header instead of calculating it

## Updates

* `src/components/sessionsList/sessionsList.js`
   * update to not calculate dayName but instead use the JSON value
* updated the `AgendaDay` model and style slightly

## Testing

* run `keg evf pack run evf:zen-541-dayname-label`
* navigate to http://evf-zen-541-dayname-label.local.kegdev.xyz/
* Open the JSON editor
* Update the `dayName` properties
    * [image](https://user-images.githubusercontent.com/3317835/107407890-79d57300-6ac7-11eb-8895-5274723bd82a.png)
* hit `Apply Changes`
* verify that the dayToggle text changes based on the current day.dayName
* Verify it truncates when the text is long enough

