### PR TITLE
ZEN-543: Develop Tag

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -6,7 +6,7 @@ ARG GIT_APP_BRANCH=master
 ARG KEG_COPY_LOCAL
 
 # Add a FROM for the tap-base image to we can copy content from it
-ARG KEG_BASE_IMAGE=ghcr.io/simpleviewinc/tap:master
+ARG KEG_BASE_IMAGE=ghcr.io/simpleviewinc/tap:develop
 FROM $KEG_BASE_IMAGE as tap-base
 
 ARG DOC_APP_PATH=/keg/tap

--- a/container/values.yml
+++ b/container/values.yml
@@ -26,7 +26,7 @@ env:
   KEG_CONTEXT_PATH: "{{ cli.taps.evf.path }}"
   
   # Image to use when building evf
-  KEG_BASE_IMAGE: ghcr.io/simpleviewinc/tap:master
+  KEG_BASE_IMAGE: ghcr.io/simpleviewinc/tap:develop
 
   # Image to use when running evf
   KEG_IMAGE_FROM: ghcr.io/simpleviewinc/evf:develop

--- a/container/values.yml
+++ b/container/values.yml
@@ -29,7 +29,7 @@ env:
   KEG_BASE_IMAGE: ghcr.io/simpleviewinc/tap:master
 
   # Image to use when running evf
-  KEG_IMAGE_FROM: ghcr.io/simpleviewinc/evf:master
+  KEG_IMAGE_FROM: ghcr.io/simpleviewinc/evf:develop
 
   # --- DOCKER ENV CONTEXT --- #
 


### PR DESCRIPTION
**Ticket**: [ZEN-543](https://jira.simpleviewtools.com/browse/ZEN-543)

## Context

* As part of ZEN-543, we determined we should change the default docker image tag from "master" to "develop" for clarity and consistency with the git branches

## Goal

* Update all references of the old "master" to "develop"
* Ensure building images uses "develop"


## Updates
* `container/Dockerfile`
  * updated keg base image to be `tap:develop`
* `container/values.yml`
  * updated tag to "develop"

## Testing

* follow the "setup" section in the testing notes here: https://github.com/simpleviewinc/keg-cli/pull/59
  * you don't have to delete all images, though, just `evf`
* `keg evf build`
* verify it is tagged with "develop"
