### PR TITLE
Bundle Automation

### DIFF
--- a/container/docker-compose.yml
+++ b/container/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     environment:
       - CHOKIDAR_USEPOLLING
       - DOC_APP_PATH
+      - DOC_BUILD_PATH
       - DOC_CORE_PATH
       - DOC_COMPONENTS_PATH
       - DOC_JSUTILS_PATH

--- a/container/run.sh
+++ b/container/run.sh
@@ -1,32 +1,26 @@
 #!/usr/bin/env
 
+# Ensure required envs are set
+[[ -z "$KEG_PROXY_PORT" ]] && KEG_PROXY_PORT=19006
+[[ -z "$DOC_BUILD_PATH" ]] && DOC_BUILD_PATH=/keg/tap-build
+
+# If DOC_TAP_PATH is set, use that for the DOC_APP_PATH
+[[ "$DOC_TAP_PATH" ]] && export DOC_APP_PATH=$DOC_TAP_PATH
+# Otherwise set the default if it's not already set
+[[ -z "$DOC_APP_PATH" ]] && DOC_APP_PATH=/keg/tap
+
 # If the no KEG_DOCKER_EXEC env is set, just sleep forever
 # This is to keep our container running forever
-if [[ -z "$KEG_DOCKER_EXEC" ]]; then
-  tail -f /dev/null
-  exit 0
+[[ -z "$KEG_DOCKER_EXEC" ]] && tail -f /dev/null && exit 0;
 
-else
-
-  # Ensure the DOC_APP_PATH is set
-  if [[ -z "$DOC_APP_PATH" ]]; then
-    DOC_APP_PATH=/keg/tap
-  fi
-
-  # cd into the tap repo
-  cd $DOC_APP_PATH
-
-  if [[ -z "$KEG_EXEC_CMD" ]]; then
-    KEG_EXEC_CMD="tap:start"
-  fi
-
-  # This is a temp fix until we are able to update expo
-  if [[ -d "$DOC_APP_PATH/node_modules/keg-core/.expo" ]]; then
-    rm -rf $DOC_APP_PATH/node_modules/keg-core/.expo
-  fi
-
-  # Start the tap instance
-  echo $"[ KEG-CLI ] Running command 'yarn $KEG_EXEC_CMD'" >&2
-  yarn $KEG_EXEC_CMD
-
+# Check the NODE_ENV, and use that to know which environment to start
+# For non-development environments, we want to serve the bundle if it exists
+if [[ ! " development develop local test " =~ " $NODE_ENV " ]]; then
+  [[ -d "$DOC_BUILD_PATH" ]] && npx serve $DOC_BUILD_PATH --cors -n -l $KEG_PROXY_PORT && exit 0;
+  echo $"[ KEG-CLI ] Serve path $DOC_BUILD_PATH does not exist!" >&2
 fi
+
+# Serve the app bundle in development environemnts
+echo $"[ KEG-CLI ] Running development server!" >&2
+cd $DOC_APP_PATH
+yarn ${KEG_EXEC_CMD:-tap:start}

--- a/container/values.yml
+++ b/container/values.yml
@@ -1,4 +1,14 @@
-
+actions:
+  tap:
+    build:
+      cmds:
+        - yarn web:build
+        - rm -rf {{ envs.DOC_BUILD_PATH }}
+        - cp -R {{ envs.DOC_CORE_PATH }}/web-build {{ envs.DOC_BUILD_PATH }}
+    serve:
+      detached: true
+      cmds:
+        - npx serve {{ envs.DOC_BUILD_PATH }} --cors -n -l {{ envs.KEG_PROXY_PORT }}
 env:
   # --- LOCAL ENV CONTEXT --- #
   COMPONENTS_PATH: "{{ cli.paths.components }}"
@@ -35,6 +45,9 @@ env:
 
   # Default location of the tap in the docker container
   DOC_APP_PATH: /keg/tap
+
+  # Default location of the tap web bundle export
+  DOC_BUILD_PATH: /keg/tap-build
 
   # Defines the location in a docker container for a dependency
   # This allows mutagen to know where to sync the local version of the dependency

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "start": "cd node_modules/keg-core; expo start",
     "watch": "nodemon --watch node_modules/keg-core/core/base/configs --watch node_modules/keg-core/app.json --watch node_modules/keg-core/package.json --watch configs --watch package.json --watch tap.json --exec",
     "web": "cd node_modules/keg-core; yarn web",
+    "web:build": "cd node_modules/keg-core; yarn build:web",
     "tap:start": "cd node_modules/keg-core; yarn tap:start",
     "keg": "cd node_modules/keg-core; yarn",
     "format:eslint": "eslint --config ./configs/eslintrc.config.js . --resolve-plugins-relative-to ./ --fix --quiet",


### PR DESCRIPTION
**Ticket**: [ZEN-609](https://jira.simpleviewtools.com/browse/ZEN-609)

* This PR should be reviewed along side [this keg-cli pr](https://github.com/simpleviewinc/keg-cli/pull/61)


## Context
* When we run our docker packages on the staging server, there are a number of features that we don't need, like running in development modes
* These features slow down the execution, and in some cases prevent resolving the application url

## Goal
* Automate bundling the application when the docker image is created
* This will allow the staging server serve the bundle instead of using the development server

## Updates
* `container/docker-compose.yml`
  * Added `DOC_BUILD_PATH` env
* `container/run.sh`
  * Updated to run a command based on `NODE_ENV`
  * Allows running the bundled app in non-development environments
* `container/values.yml`
  * Added actions for bundling and serving the app
* `package.json`
  * Added `web:build` script

## Tests

**Setup**
* Pull this PR for the keg-cli => `keg cli && keg pr 61`
* Pull this PR => `keg evf && keg pr 129`

**Test 1*
* Start the tap => `keg evf start`
* Connect to the container with => `keg evf att`
* Then navigate to the keg-core folder => `cd /keg/tap/node_modules/keg-core/`
  * Update the keg-core's `package.json` file
    * Change the `"homepage"` key to be `/`
    * This fix is part of another pr, so we have to do it manually for now
    * [Looks like this](https://prnt.sc/11w5pzq)
* Next open another terminal window run => `keg evf pack`
  * Ensure it automatically runs the `tap.build` action defined in the `container/Values.yml` file
  * [Looks like this](https://prnt.sc/11w7zbc)
* After it's been built, you can press `ctl+c` to cancel to exit that task or let it finish and push to the docker provider
  * I've already pushed images to the provider, so there's not need for you to do this unless you want to
  * The image will be used in a later test

**Test 2**
* Leave the evf tap container running, but stop **ALL** running servers
  * This includes the one started from the `keg evf start` command
* Connect to the container with => `keg evf att`
* Navigate to the build folder with => `cd /keg/tap-build`
  * Ensure the folder exists, and contains the build files
  * [Looks like this](https://prnt.sc/11w83vd)

**Test 3**
* Run the command `bash /keg/tap/container/run.sh`
  * Ensure this starts the development server
  * [Looks like this](https://prnt.sc/11w84yc)
  * Once verified, hit `ctrl+c` to stop the server
* Next, run the command `NODE_ENV=staging bash /keg/tap/container/run.sh`
  * Ensure this starts the bundle server instead
  * [Looks like this](https://prnt.sc/11w85xa)
  * Navigate to http://evf-zen-609-automate-package-exec.local.keghub.io/ in your browser
    * Ensure the tap works as expected

**Test 4**
* Kill the running evf tap container => `keg evf kill`
* Next, run the command `keg evf pack run --package evf:zen-609-automate-package-exec --env staging`
  * This should start the evf tap using the bundled application code
  * [Looks like this](https://prnt.sc/11w8p4t)
* Navigate to http://evf-zen-609-automate-package-exec.local.keghub.io/ in your browser
  * Ensure the tap works as expected
