### PR TITLE
ZEN-649: Checkbox Accessibility Updates

### DIFF
--- a/src/components/booking/attendeeCheckboxItem.js
+++ b/src/components/booking/attendeeCheckboxItem.js
@@ -23,12 +23,15 @@ const CheckboxLabel = ({
   style,
   ...rest
 }) => {
-  const merged = useMemo(() => ({ ...style, ...textStyle }), [ style, textStyle ])
+  const defaultLabelStyles = useMemo(() => ({ ...style, ...textStyle }), [
+    style,
+    textStyle,
+  ])
   return waiting ? (
     <WaitingItem
       {...rest}
       style={style}
-      labelFor={htmlFor}
+      htmlFor={htmlFor}
       name={text}
       textClassName={textClassName}
       textStyle={textStyle}
@@ -38,7 +41,7 @@ const CheckboxLabel = ({
       {...rest}
       htmlFor={htmlFor}
       className={textClassName}
-      style={merged}
+      style={defaultLabelStyles}
     >
       { text }
     </Label>

--- a/src/components/booking/attendeeCheckboxItem.js
+++ b/src/components/booking/attendeeCheckboxItem.js
@@ -52,6 +52,7 @@ export const AttendeeCheckboxItem = props => {
   return (
     <EvfCheckbox
       id={checkboxId}
+      type={isWaiting ? 'alternate' : 'primary'}
       styles={styles}
       checked={checked}
       onChange={onAttendeeSelected}

--- a/src/components/booking/attendeeCheckboxItem.js
+++ b/src/components/booking/attendeeCheckboxItem.js
@@ -1,52 +1,7 @@
 import React, { useMemo } from 'react'
 import { EvfCheckbox } from 'SVComponents/checkbox/evfCheckbox'
 import { isEmpty, set } from '@keg-hub/jsutils'
-import { WaitingItem } from './waitingItem'
-import { Label } from 'SVComponents/form/label'
-
-/**
- * Label text for the attendee checkbox
- * @param {boolean} props.waiting - true if attendee is on waiting list
- * @param {string} props.text - label string
- * @param {string} props.htmlFor - the "for" attribute for the underlying label element
- * @param {string} props.textClassName - class name for the label text
- * @param {Object} props.textStyle - styles for the label text
- * @param {Object} props.style - styles for any wrapping content around the label
- * @param {Object} props.* - remaining props are passed directly to the element
- */
-const CheckboxLabel = ({
-  waiting,
-  text,
-  htmlFor,
-  textClassName,
-  textStyle,
-  style,
-  ...rest
-}) => {
-  const defaultLabelStyles = useMemo(() => ({ ...style, ...textStyle }), [
-    style,
-    textStyle,
-  ])
-  return waiting ? (
-    <WaitingItem
-      {...rest}
-      style={style}
-      htmlFor={htmlFor}
-      name={text}
-      textClassName={textClassName}
-      textStyle={textStyle}
-    />
-  ) : (
-    <Label
-      {...rest}
-      htmlFor={htmlFor}
-      className={textClassName}
-      style={defaultLabelStyles}
-    >
-      { text }
-    </Label>
-  )
-}
+import { AttendeeCheckboxLabel } from './attendeeCheckboxLabel'
 
 /**
  * A wrapper around the checkbox component with styling and logic for
@@ -98,19 +53,19 @@ export const AttendeeCheckboxItem = props => {
     <EvfCheckbox
       id={checkboxId}
       styles={styles}
-      rightClassName={textClassName}
+      checked={checked}
       onChange={onAttendeeSelected}
       disabled={disabled}
       enableCheck={enableCheck}
-      checked={checked}
+      rightClassName={textClassName}
       RightComponent={props => (
-        <CheckboxLabel
+        <AttendeeCheckboxLabel
+          {...props}
           htmlFor={checkboxId}
-          text={text}
+          name={text}
           textClassName={textClassName}
           textStyle={textStyle}
           waiting={isWaiting}
-          {...props}
         />
       )}
     />

--- a/src/components/booking/attendeeCheckboxItem.js
+++ b/src/components/booking/attendeeCheckboxItem.js
@@ -2,6 +2,48 @@ import React, { useMemo } from 'react'
 import { EvfCheckbox } from 'SVComponents/checkbox/evfCheckbox'
 import { isEmpty, set } from '@keg-hub/jsutils'
 import { WaitingItem } from './waitingItem'
+import { Label } from 'SVComponents/form/label'
+
+/**
+ * Label text for the attendee checkbox
+ * @param {boolean} props.waiting - true if attendee is on waiting list
+ * @param {string} props.text - label string
+ * @param {string} props.htmlFor - the "for" attribute for the underlying label element
+ * @param {string} props.textClassName - class name for the label text
+ * @param {Object} props.textStyle - styles for the label text
+ * @param {Object} props.style - styles for any wrapping content around the label
+ * @param {Object} props.* - remaining props are passed directly to the element
+ */
+const CheckboxLabel = ({
+  waiting,
+  text,
+  htmlFor,
+  textClassName,
+  textStyle,
+  style,
+  ...rest
+}) => {
+  const merged = useMemo(() => ({ ...style, ...textStyle }), [ style, textStyle ])
+  return waiting ? (
+    <WaitingItem
+      {...rest}
+      style={style}
+      labelFor={htmlFor}
+      name={text}
+      textClassName={textClassName}
+      textStyle={textStyle}
+    />
+  ) : (
+    <Label
+      {...rest}
+      htmlFor={htmlFor}
+      className={textClassName}
+      style={merged}
+    >
+      { text }
+    </Label>
+  )
+}
 
 /**
  * A wrapper around the checkbox component with styling and logic for
@@ -34,10 +76,10 @@ export const AttendeeCheckboxItem = props => {
   const disabled = isAttendeeDisabled?.(id)
   const isUnnamed = !name || isEmpty(name)
   const text = isUnnamed ? 'Unnamed' : name
+  const checkboxId = `attendee-checkbox-${id}`
 
   const unnamedStyles = sectionStyles?.content?.unnamedItem?.main
   const itemStyles = sectionStyles?.content?.item?.main
-
   const styles = useMemo(
     () =>
       set({}, 'content.right', {
@@ -47,30 +89,27 @@ export const AttendeeCheckboxItem = props => {
     [ isUnnamed, itemStyles, unnamedStyles ]
   )
 
+  const textStyle = styles?.content?.right
+
   return (
     <EvfCheckbox
-      id={id}
+      id={checkboxId}
       styles={styles}
-      text={text}
-      RightComponent={
-        isWaiting &&
-        (props => (
-          <WaitingItem
-            labelFor={id}
-            name={text}
-            textClassName={textClassName}
-            textStyle={styles?.content?.right}
-            style={props.style}
-            onPress={props.onPress}
-          />
-        ))
-      }
       rightClassName={textClassName}
-      type={isWaiting ? 'alternate' : 'primary'}
       onChange={onAttendeeSelected}
       disabled={disabled}
       enableCheck={enableCheck}
       checked={checked}
+      RightComponent={props => (
+        <CheckboxLabel
+          htmlFor={checkboxId}
+          text={text}
+          textClassName={textClassName}
+          textStyle={textStyle}
+          waiting={isWaiting}
+          {...props}
+        />
+      )}
     />
   )
 }

--- a/src/components/booking/attendeeCheckboxItem.js
+++ b/src/components/booking/attendeeCheckboxItem.js
@@ -1,9 +1,7 @@
 import React, { useMemo } from 'react'
 import { EvfCheckbox } from 'SVComponents/checkbox/evfCheckbox'
-import { Text, View } from '@keg-hub/keg-components'
 import { isEmpty, set } from '@keg-hub/jsutils'
-import { useStyle, useTheme } from '@keg-hub/re-theme'
-import { isMobileSize } from 'SVUtils/theme/isMobileSize'
+import { WaitingItem } from './waitingItem'
 
 /**
  * A wrapper around the checkbox component with styling and logic for
@@ -58,6 +56,7 @@ export const AttendeeCheckboxItem = props => {
         isWaiting &&
         (props => (
           <WaitingItem
+            labelFor={id}
             name={text}
             textClassName={textClassName}
             textStyle={styles?.content?.right}
@@ -73,50 +72,5 @@ export const AttendeeCheckboxItem = props => {
       enableCheck={enableCheck}
       checked={checked}
     />
-  )
-}
-
-/**
- * Simple box indicating attendee is on the waiting list
- * @param {Object} props
- * @param {string} props.text - text to show in waiting box
- * @param {Object} props.styles - theme styles (main and content)
- */
-const WaitingBox = ({ text = 'On waiting list', styles }) => {
-  return (
-    <View style={styles?.main}>
-      <Text style={styles?.content}>{ text }</Text>
-    </View>
-  )
-}
-
-/**
- * When a user is on the waiting list, we need to display a waiting visual right of the text
- * @param {Object} props
- * @param {string} props.name
- * @param {string?} props.textClassName - classname for name of attendee
- * @param {object} props.style
- * @param {object} props.textStyle
- * @param {Function?} props.onPress
- */
-const WaitingItem = props => {
-  const { name, style, textClassName, textStyle, onPress } = props
-  const waitingStyles = useStyle('attendeeCheckboxItem.waitingItem', style)
-  const isMobile = isMobileSize(useTheme())
-
-  return (
-    <View style={waitingStyles?.main}>
-      <View style={waitingStyles?.textWrapper}>
-        <Text
-          className={textClassName}
-          style={[ waitingStyles?.text, textStyle ]}
-          onPress={onPress}
-        >
-          { name }
-          { isMobile && ' (waiting)' }
-        </Text>
-      </View>
-      { !isMobile && <WaitingBox styles={waitingStyles?.waitBox} /> }
-    </View>
   )
 }

--- a/src/components/booking/attendeeCheckboxLabel.js
+++ b/src/components/booking/attendeeCheckboxLabel.js
@@ -4,7 +4,11 @@ import { useStyle, useTheme } from '@keg-hub/re-theme'
 import { isMobileSize } from 'SVUtils/theme/isMobileSize'
 import { Label } from 'SVComponents/form/label'
 import { reStyle } from '@keg-hub/re-theme/reStyle'
+import PropTypes from 'prop-types'
 
+/**
+ * Waiting box main wrapper
+ */
 const BoxMain = reStyle(View)(theme => ({
   minHeight: 31,
   backgroundColor: 'unset',
@@ -20,16 +24,13 @@ const BoxMain = reStyle(View)(theme => ({
   alignItems: 'center',
 }))
 
+/**
+ * Waiting box text content wrapper
+ */
 const BoxContent = reStyle(Text)(theme => ({
   color: theme.colors.second,
   fontSize: 12,
   fontWeight: 500,
-}))
-
-const LabelWrapper = reStyle(View)(() => ({
-  flexDirection: 'column',
-  flexShrink: 1,
-  paddingRight: 10,
 }))
 
 /**
@@ -46,6 +47,15 @@ const WaitingBox = ({ text = 'On waiting list' }) => {
 }
 
 /**
+ * Wrapper for the label text
+ */
+const LabelWrapper = reStyle(View)(() => ({
+  flexDirection: 'column',
+  flexShrink: 1,
+  paddingRight: 10,
+}))
+
+/**
  * When a user is on the waiting list, we need to display a waiting visual right of the text
  * @param {Object} props
  * @param {string} props.name
@@ -53,9 +63,18 @@ const WaitingBox = ({ text = 'On waiting list' }) => {
  * @param {object} props.style
  * @param {object} props.textStyle
  * @param {Function?} props.onPress
+ * @param {boolean} props.waiting - true if attendee is waiting
  */
-export const WaitingItem = props => {
-  const { htmlFor, name, style, textClassName, textStyle, onPress } = props
+export const AttendeeCheckboxLabel = props => {
+  const {
+    htmlFor,
+    name,
+    style,
+    textClassName,
+    textStyle,
+    onPress,
+    waiting,
+  } = props
   const waitingStyles = useStyle('attendeeCheckboxItem.waitingItem', style)
   const isMobile = isMobileSize(useTheme())
 
@@ -69,10 +88,18 @@ export const WaitingItem = props => {
           onPress={onPress}
         >
           { name }
-          { isMobile && ' (waiting)' }
+          { isMobile && waiting && ' (waiting)' }
         </Label>
       </LabelWrapper>
-      { !isMobile && <WaitingBox styles={waitingStyles?.waitBox} /> }
+      { !isMobile && waiting && <WaitingBox styles={waitingStyles?.waitBox} /> }
     </View>
   )
+}
+
+AttendeeCheckboxLabel.propTypes = {
+  name: PropTypes.string,
+  textClassName: PropTypes.string,
+  textStyle: PropTypes.object,
+  onPress: PropTypes.func,
+  waiting: PropTypes.bool,
 }

--- a/src/components/booking/groupBooker.js
+++ b/src/components/booking/groupBooker.js
@@ -52,7 +52,6 @@ GroupBookerBody.propTypes = {
 const TopSection = ({ styles }) => {
   // use correct wording depending on number of spots remaining
   const { state } = useGroupBookingContext()
-  const showRequireSymbol = !isBookingModified(state)
   const placeText = state.capacity === 1 ? 'place' : 'places'
   return (
     <View
@@ -64,9 +63,6 @@ const TopSection = ({ styles }) => {
         style={styles?.content?.instructionText}
       >
         Select sessions for your group:{ ' ' }
-        { showRequireSymbol && (
-          <Text style={styles?.content?.instructionAsterisk}>*</Text>
-        ) }
       </Text>
       { state.showCapacity && (
         <Text

--- a/src/components/booking/waitingItem.js
+++ b/src/components/booking/waitingItem.js
@@ -3,18 +3,45 @@ import { Text, View } from '@keg-hub/keg-components'
 import { useStyle, useTheme } from '@keg-hub/re-theme'
 import { isMobileSize } from 'SVUtils/theme/isMobileSize'
 import { Label } from 'SVComponents/form/label'
+import { reStyle } from '@keg-hub/re-theme/reStyle'
+
+const BoxMain = reStyle(View)(theme => ({
+  minHeight: 31,
+  backgroundColor: 'unset',
+  cursor: 'default',
+  borderRadius: 2,
+  borderWidth: 1,
+  borderStyle: 'solid',
+  borderColor: theme.colors.second,
+  width: 100,
+  height: 31,
+  padding: 0,
+  justifyContent: 'center',
+  alignItems: 'center',
+}))
+
+const BoxContent = reStyle(Text)(theme => ({
+  color: theme.colors.second,
+  fontSize: 12,
+  fontWeight: 500,
+}))
+
+const LabelWrapper = reStyle(View)(() => ({
+  flexDirection: 'column',
+  flexShrink: 1,
+  paddingRight: 10,
+}))
 
 /**
  * Simple box indicating attendee is on the waiting list
  * @param {Object} props
  * @param {string} props.text - text to show in waiting box
- * @param {Object} props.styles - theme styles (main and content)
  */
-const WaitingBox = ({ text = 'On waiting list', styles }) => {
+const WaitingBox = ({ text = 'On waiting list' }) => {
   return (
-    <View style={styles?.main}>
-      <Text style={styles?.content}>{ text }</Text>
-    </View>
+    <BoxMain>
+      <BoxContent>{ text }</BoxContent>
+    </BoxMain>
   )
 }
 
@@ -28,15 +55,15 @@ const WaitingBox = ({ text = 'On waiting list', styles }) => {
  * @param {Function?} props.onPress
  */
 export const WaitingItem = props => {
-  const { labelFor, name, style, textClassName, textStyle, onPress } = props
+  const { htmlFor, name, style, textClassName, textStyle, onPress } = props
   const waitingStyles = useStyle('attendeeCheckboxItem.waitingItem', style)
   const isMobile = isMobileSize(useTheme())
 
   return (
     <View style={waitingStyles?.main}>
-      <View style={waitingStyles?.textWrapper}>
+      <LabelWrapper>
         <Label
-          htmlFor={labelFor}
+          htmlFor={htmlFor}
           className={textClassName}
           style={textStyle}
           onPress={onPress}
@@ -44,7 +71,7 @@ export const WaitingItem = props => {
           { name }
           { isMobile && ' (waiting)' }
         </Label>
-      </View>
+      </LabelWrapper>
       { !isMobile && <WaitingBox styles={waitingStyles?.waitBox} /> }
     </View>
   )

--- a/src/components/booking/waitingItem.js
+++ b/src/components/booking/waitingItem.js
@@ -32,15 +32,13 @@ export const WaitingItem = props => {
   const waitingStyles = useStyle('attendeeCheckboxItem.waitingItem', style)
   const isMobile = isMobileSize(useTheme())
 
-  console.error('wow')
-
   return (
     <View style={waitingStyles?.main}>
       <View style={waitingStyles?.textWrapper}>
         <Label
-          for={labelFor}
+          htmlFor={labelFor}
           className={textClassName}
-          style={[ waitingStyles?.text, textStyle ]}
+          style={textStyle}
           onPress={onPress}
         >
           { name }

--- a/src/components/booking/waitingItem.js
+++ b/src/components/booking/waitingItem.js
@@ -1,0 +1,53 @@
+import React from 'react'
+import { Text, View } from '@keg-hub/keg-components'
+import { useStyle, useTheme } from '@keg-hub/re-theme'
+import { isMobileSize } from 'SVUtils/theme/isMobileSize'
+import { Label } from 'SVComponents/form/label'
+
+/**
+ * Simple box indicating attendee is on the waiting list
+ * @param {Object} props
+ * @param {string} props.text - text to show in waiting box
+ * @param {Object} props.styles - theme styles (main and content)
+ */
+const WaitingBox = ({ text = 'On waiting list', styles }) => {
+  return (
+    <View style={styles?.main}>
+      <Text style={styles?.content}>{ text }</Text>
+    </View>
+  )
+}
+
+/**
+ * When a user is on the waiting list, we need to display a waiting visual right of the text
+ * @param {Object} props
+ * @param {string} props.name
+ * @param {string?} props.textClassName - classname for name of attendee
+ * @param {object} props.style
+ * @param {object} props.textStyle
+ * @param {Function?} props.onPress
+ */
+export const WaitingItem = props => {
+  const { labelFor, name, style, textClassName, textStyle, onPress } = props
+  const waitingStyles = useStyle('attendeeCheckboxItem.waitingItem', style)
+  const isMobile = isMobileSize(useTheme())
+
+  console.error('wow')
+
+  return (
+    <View style={waitingStyles?.main}>
+      <View style={waitingStyles?.textWrapper}>
+        <Label
+          for={labelFor}
+          className={textClassName}
+          style={[ waitingStyles?.text, textStyle ]}
+          onPress={onPress}
+        >
+          { name }
+          { isMobile && ' (waiting)' }
+        </Label>
+      </View>
+      { !isMobile && <WaitingBox styles={waitingStyles?.waitBox} /> }
+    </View>
+  )
+}

--- a/src/components/checkbox/evfCheckbox.js
+++ b/src/components/checkbox/evfCheckbox.js
@@ -41,6 +41,7 @@ export const EvfCheckbox = props => {
 
   return (
     <Checkbox
+      id={id}
       styles={checkboxStyles}
       RightComponent={RightComponent || text}
       onChange={handler}

--- a/src/components/form/index.js
+++ b/src/components/form/index.js
@@ -1,0 +1,1 @@
+export * from './label'

--- a/src/components/form/label/index.js
+++ b/src/components/form/label/index.js
@@ -1,0 +1,1 @@
+export * from './label'

--- a/src/components/form/label/label.native.js
+++ b/src/components/form/label/label.native.js
@@ -1,3 +1,4 @@
-import { Text } from '@keg-hub/keg-components'
+import { Label as KegLabel } from '@keg-hub/keg-components'
 
-export const Label = Text
+export const Label = KegLabel
+

--- a/src/components/form/label/label.native.js
+++ b/src/components/form/label/label.native.js
@@ -1,0 +1,3 @@
+import { Text } from '@keg-hub/keg-components'
+
+export const Label = Text

--- a/src/components/form/label/label.web.js
+++ b/src/components/form/label/label.web.js
@@ -1,6 +1,24 @@
-import { unstable_createElement as createElement } from 'react-native-web'
+import React from 'react'
+import { Text } from '@keg-hub/keg-components'
+import { reStyle } from '@keg-hub/re-theme/reStyle'
+import PropTypes from 'prop-types'
 
+const StyledLabel = reStyle('label')(() => ({ margin: 0, cursor: 'pointer' }))
+
+/**
+ * Label component
+ * @param {*} props
+ * @returns
+ */
 export const Label = props => {
-  const { for: htmlFor, ...rest } = props
-  return createElement('label', { htmlFor, ...rest })
+  const { children, onPress, ...rest } = props
+  return (
+    <Text onPress={onPress}>
+      <StyledLabel {...rest}> { children } </StyledLabel>
+    </Text>
+  )
+}
+
+Label.propTypes = {
+  onPress: PropTypes.func,
 }

--- a/src/components/form/label/label.web.js
+++ b/src/components/form/label/label.web.js
@@ -1,0 +1,6 @@
+import { unstable_createElement as createElement } from 'react-native-web'
+
+export const Label = props => {
+  const { for: htmlFor, ...rest } = props
+  return createElement('label', { htmlFor, ...rest })
+}

--- a/src/components/tapIndex.js
+++ b/src/components/tapIndex.js
@@ -1,5 +1,6 @@
 export * from './dates'
 export * from './labels'
+export * from './form'
 export * from './grid'
 export * from './modals'
 export * from './sessionTime'

--- a/src/theme/components/booking/attendeeCheckboxItem.js
+++ b/src/theme/components/booking/attendeeCheckboxItem.js
@@ -1,5 +1,3 @@
-import { colors } from '../../colors'
-
 const text = {
   $xsmall: {
     fontSize: '0.8em',
@@ -30,34 +28,6 @@ export const attendeeCheckboxItem = {
         flexWrap: 'nowrap',
       },
     },
-    textWrapper: {
-      flexDirection: 'column',
-      flexShrink: 1,
-      pR: 10,
-    },
     text,
-    waitBox: {
-      main: {
-        $web: {
-          minHeight: 31,
-          backgroundColor: 'unset',
-          cursor: 'default',
-          borderRadius: 2,
-          borderWidth: 1,
-          borderStyle: 'solid',
-          borderColor: colors.second,
-          width: 100,
-          height: 31,
-          padding: 0,
-          justifyContent: 'center',
-          alignItems: 'center',
-        },
-      },
-      content: {
-        color: colors.second,
-        fontSize: 12,
-        fontWeight: 500,
-      },
-    },
   },
 }

--- a/src/theme/components/modals/groupBookingModal.js
+++ b/src/theme/components/modals/groupBookingModal.js
@@ -35,9 +35,6 @@ export const groupBookingModal = {
           },
           content: {
             instructionText: groupBookingTextStyle,
-            instructionAsterisk: {
-              color: colors.red,
-            },
             infoText: {
               ...groupBookingTextStyle,
               color: colors.lightGray,


### PR DESCRIPTION
**Ticket**: [ZEN-649](https://jira.simpleviewtools.com/browse/ZEN-649)

## Goal

* Use a label with the attendee checkbox item and link it to the input element, to improve accessibility

## Updates
* `src/components/booking/attendeeCheckboxItem.js`
  * updated the `id` to be more clear
  * extracted the label component to a separate file
* `src/components/booking/attendeeCheckboxLabel.js`
  * this is the extracted label component
  * updated it to use a `label` instead of `Text` (on web)
  * it now handles both the waiting and non-waiting state 
  * refactored it to use styled components (where possible -- to do more, we need to update `reStyle` to support size keys)
* `src/components/booking/groupBooker.js`
  * this is just removing the modified asterisk that they requested we remove. It's technically handled by another ticket but I knew exactly what to do so I just did it
* `src/components/checkbox/evfCheckbox.js`
  * updated to pass down the id prop
* `src/components/form/label/label.{platform}.js`
  * This is just a simple label element
  * on native, it's just `Text`
  * on web, it's a `label`
    * I did this because while the `react-native-web` `Text` element can support being a `label` element for accessibility, it does not accept the `for`/`htmlFor` attribute
* `src/theme/components/booking/attendeeCheckboxItem.js`
  * removing styles that are now defined in styled components

## Testing

### Setup
* Open this branch in a codespace. Read the guide [here](https://docs.github.com/en/codespaces/developing-in-codespaces/using-codespaces-for-pull-requests#opening-a-pull-request-in-codespaces)
  * I could send a link to my public codespace, but it stops itself after inactivity so it might be down if I did
* `yarn install`
* `yarn web`

### Instructions
* For both mobile and desktop web:
  * Select the booking button for the session titled `Session on day 2 - limited capacity`
  * Verify that the checkboxes and their associated attendee names are all styled correctly (see the test consumer: https://simpleviewinc.github.io/keg-test-consumer/ for comparison)
  * Inspect the DOM, and verify that a `label` element is used to display the attendee name
  * Verify that it has a `for` attribute, and take note of its value
  * Verify that the value matches the associated checkbox's `id` attribute
  * Also verify that you see no red asterisk next to he `Select sessions for your group` text when you first open the modal
