### PR TITLE
ZEN-649 : Ensure accessibilityLabel that gets ported to alt , is the …

### DIFF
--- a/src/components/modals/presenterDetails.js
+++ b/src/components/modals/presenterDetails.js
@@ -74,6 +74,7 @@ const Body = ({ presenter, styles }) => {
           className={`ef-presenter-picture`}
           styles={{ image: imageStyle }}
           source={presenter.photographUrl || placeholderImage}
+          accessibilityLabel={getPresenterFullName(presenter)}
         />
         <View
           className={`ef-modal-presenter-container`}


### PR DESCRIPTION
…presenter name so that it lives up to accessibility standards

**Ticket**: https://jira.simpleviewtools.com/browse/ZEN-649

## Context

* Updates to improve WCAG Accessibility Standards

## Goal

* When Presenter modal is opened , ensure presenter name is set as the altText for the image of the presenter

## Updates

* taps/tap-events-force/src/components/modals/presenterDetails.js
  * A new property 'AccessibilityLabel' has been added to the presenter image that translates into altText

## Testing

* Setup
  * Run the command => keg evf pack run evf:zen-649-accessibilitystandards-v2
  * Navigate to http://evf-zen-649-accessibilitystandards-v2.local.keghub.io/

* Testing presenter name
  * Click on any presenter name in session . It should open the presenter modal
  * Open the dev console
  * Click on the presenter image and verify that that the altText for the element is now set to the presenter name

