### PR TITLE
ZEN-663 iFrame Hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keg-hub/tap-events-force",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Events Force Tap for the Keg",
   "main": "index.js",
   "author": "Lance Tipton <lancetipton04@gmail.com>",

--- a/src/components/sessionsList/sessionsList.js
+++ b/src/components/sessionsList/sessionsList.js
@@ -18,7 +18,7 @@ import { getWindow } from 'SVUtils/platform/getWindow'
 const sectionOffset = -45
 
 /**
- * TODO: replace this with keg-core utility once it's released
+ * TODO: replace this with keg-core utility once >=v9.5.0 is released
  * @returns {Boolean} true if this react app is in a web environment and also rendered inside of an iframe
  */
 const isIFrame = () => {
@@ -124,7 +124,6 @@ const useOnScrollChange = (sections, currentDay, onDayChange) => {
 export const SessionsList = props => {
   const { settings, sessions, onDayChange, ...itemProps } = props
   const currentDay = settings.agendaSettings.activeDayNumber || 1
-  console.log({ currentDay })
 
   const theme = useTheme()
   const agenda = useAgenda()

--- a/src/components/sessionsList/sessionsList.js
+++ b/src/components/sessionsList/sessionsList.js
@@ -1,7 +1,7 @@
+import React, { useMemo, useCallback, useRef } from 'react'
 import { isMobileSize } from 'SVUtils/theme'
 import { useTheme } from '@keg-hub/re-theme'
 import { reduceObj, noPropArr } from '@keg-hub/jsutils'
-import React, { useMemo, useCallback } from 'react'
 import { SessionsDivider } from './sessionsDivider'
 import { useAgenda } from 'SVHooks/models/useAgenda'
 import { GridContainer } from 'SVContainers/gridContainer'
@@ -9,12 +9,21 @@ import { SessionsHeader } from 'SVComponents/sessionsHeader'
 import { SectionList } from '@keg-hub/keg-components'
 import { useStylesCallback, useDimensions } from '@keg-hub/re-theme'
 import { setDay } from 'SVActions/session/dates'
+import { getWindow } from 'SVUtils/platform/getWindow'
 
 /**
  * Default scroll offset for the section headers based on the size
  * @number
  */
 const sectionOffset = -45
+
+/**
+ * @returns {Boolean} true if this react app is in a web environment and also rendered inside of an iframe
+ */
+const isIFrame = () => {
+  const win = getWindow()
+  return win ? win.location !== win.parent.location : false
+}
 
 /**
  * Hook to memoize the sessions styles
@@ -24,16 +33,20 @@ const sectionOffset = -45
  */
 const useListStyles = () => {
   const dims = useDimensions()
+  const { current: initialHeight } = useRef(dims.height)
   return useStylesCallback(
     (theme, styles, height) => {
       const itemHeight =
         (theme.get('gridItem')?.main?.minHeight || 300) + sectionOffset
+
+      const viewportHeight = isIFrame() ? initialHeight : height
+
       return !height
         ? theme.get('sessionsList')
         : theme.get('sessionsList', {
           content: {
             list: {
-              marginBottom: height - itemHeight,
+              marginBottom: viewportHeight - itemHeight,
             },
           },
         })
@@ -110,6 +123,7 @@ const useOnScrollChange = (sections, currentDay, onDayChange) => {
 export const SessionsList = props => {
   const { settings, sessions, onDayChange, ...itemProps } = props
   const currentDay = settings.agendaSettings.activeDayNumber || 1
+  console.log({ currentDay })
 
   const theme = useTheme()
   const agenda = useAgenda()

--- a/src/components/sessionsList/sessionsList.js
+++ b/src/components/sessionsList/sessionsList.js
@@ -18,11 +18,12 @@ import { getWindow } from 'SVUtils/platform/getWindow'
 const sectionOffset = -45
 
 /**
+ * TODO: replace this with keg-core utility once it's released
  * @returns {Boolean} true if this react app is in a web environment and also rendered inside of an iframe
  */
 const isIFrame = () => {
   const win = getWindow()
-  return win ? win.location !== win.parent.location : false
+  return win ? win !== win.parent : false
 }
 
 /**


### PR DESCRIPTION
**Ticket**: [ZEN-663](https://jira.simpleviewtools.com/browse/zen-663)

## Goal

* Fix the infinite iframe-resizing bug for EventsForce

## Updates

* `src/components/sessionsList/sessionsList.js`
  * updated `marginBottom` of sessions list to be computed only once when we detect that we are inside of an iframe, otherwise it behaves the same

## Testing

* `keg consumer pack run --package consumer:zen-663-resizer`
  * this starts up the keg-test-consumer with this branch of tap-events-force synced-in
  * it also configures it with the iframe-resizer plugin
* open it in your browser: http://consumer-zen-663-resizer.local.keghub.io
* Verify that the sessions list looks and behaves normal
* Next, run `keg && cd external && git clone https://github.com/simpleviewinc/iframe-tester-evf && cd iframe-tester-evf`
* `yarn install`
* `IFRAME_SRC=http://consumer-zen-663-resizer.local.keghub.io yarn dev`
* This will start up an application that renders the consumer as an iframe, and it uses the iframe resizer plugin to set the height
  * it sets up the iframe and plugin identically to the EventsForce wordpress environment 
* Verify that the plugin does not get stuck in a loop of resizing the iframe
  * note: it's expected that there will not be a large margin at the bottom of the page
