### PR TITLE
Add new action to reject outdated PRs

### DIFF
--- a/.github/workflows/checkOutdated.yml
+++ b/.github/workflows/checkOutdated.yml
@@ -1,0 +1,10 @@
+name: Check if Outdated
+
+on:
+  pull_request:
+
+jobs:
+  check-if-outdated:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: guyarb/deny-not-updated-branch@v1.0.0


### PR DESCRIPTION
## Goal
* The dev team has agreed that no PR should be reviewed or QA-tested unless it is up to date with the `develop`
* This github action should automatically check that
* We only need to check for a green check-mark when a PR is opened

## Testing
* Verify the action ran on this PR and succeeded:

![image](https://user-images.githubusercontent.com/9517356/139343707-6ed2bee4-8211-4d87-b0bd-c9a337b87e17.png)


## Notes
* We should gradually add this action to any repo we work on