### PR TITLE
Group Modal Fixes and Tests

### DIFF
--- a/src/components/__tests__/bookingButton.integration.js
+++ b/src/components/__tests__/bookingButton.integration.js
@@ -15,7 +15,7 @@ const getSelectBtnWithOnlyText = () =>
 const getWaitingListBtnWithOnlyText = () =>
   screen.getByRole('button', { name: 'WAITING LIST' })
 
-describe('Booking Button', () => {
+describe('Booking Button - Integration', () => {
   it('should display BUY <price> FOR an active session with price and NO waiting list.', async () => {
     render(<Sessions sessionAgendaProps={activeSessionWithPrice} />)
 

--- a/src/components/__tests__/dayToggle.integration.js
+++ b/src/components/__tests__/dayToggle.integration.js
@@ -13,7 +13,7 @@ const getDecrementBtn = () =>
 const findHeadingByContent = async expectedText =>
   await screen.findByRole('heading', { name: expectedText })
 
-describe('SessionsList - Day Toggle', () => {
+describe('Day Toggle - Integration', () => {
   beforeEach(async () => {
     window.scroll = jest.fn()
     render(<Sessions sessionAgendaProps={testData} />)

--- a/src/components/__tests__/filterModal.integration.js
+++ b/src/components/__tests__/filterModal.integration.js
@@ -19,7 +19,7 @@ const applyFilter = () => {
   return userEvent.click(btn)
 }
 
-describe('Filter Modal Integration Test', () => {
+describe('Filter Modal - Integration', () => {
   beforeEach(async () => {
     window.scroll = jest.fn()
     render(<Sessions sessionAgendaProps={testData} />)

--- a/src/components/__tests__/groupBooker.integration.js
+++ b/src/components/__tests__/groupBooker.integration.js
@@ -1,14 +1,65 @@
+import '@testing-library/jest-dom'
 import React from 'react'
-import { onWaitingList } from 'SVEvfMocks/eventsforce/bookingStates/onWaitingList'
+import testData from 'SVEvfMocks/eventsforce/testData.js'
 import userEvent from '@testing-library/user-event'
 import { Sessions } from 'SVComponents/sessions'
-import { render, screen } from 'testUtils'
+import { render, screen, within } from 'testUtils'
 
-const {
-  group: { capacity: waitingListCapacityTestData },
-} = onWaitingList
+const mockSession = {
+  allowBooking: true,
+  identifier: '1',
+  name: 'Session w/ Waiting List',
+  dayNumber: 1,
+  startDateTimeLocal: '2020-08-03 09:00:00',
+  endDateTimeLocal: '2020-08-03 13:30:00',
+  presenterIdentifiers: [ '1', '2' ],
+  labelIdentifiers: [ '1', '2' ],
+  locationIdentifier: '1',
+  liveVideoUrl: 'https://us02web.zoom.us/j/1234',
+  recordedVideoUrl: 'https://www.youtube.com/watch?v=21X5lGlDOfg',
+  restrictToAttendeeCategories: [],
+  capacity: {
+    isUnlimited: false,
+    remainingPlaces: 0,
+    isWaitingListAvailable: true,
+    waitingListRemainingPlaces: 1,
+  },
+  price: {
+    currency: 'USD',
+    amount: 923.0,
+  },
+}
 
-import '@testing-library/jest-dom'
+const waitingListData = {
+  ...testData,
+  sessions: [mockSession],
+  attendees: [
+    {
+      bookedTicketIdentifier: '1',
+      name: 'Mr Frank Smith',
+      attendeeCategoryIdentifier: '1',
+      bookedDays: [1],
+      bookedSessions: [],
+      waitingListSessions: ['1'],
+    },
+    {
+      bookedTicketIdentifier: '3',
+      name: 'Dr Lucy Jones',
+      attendeeCategoryIdentifier: '1',
+      bookedDays: [ 1, 2 ],
+      bookedSessions: [],
+      waitingListSessions: ['1'],
+    },
+    {
+      bookedTicketIdentifier: '10',
+      name: 'Ms. Teresa Waiting',
+      attendeeCategoryIdentifier: '2',
+      bookedDays: [ 1, 2 ],
+      bookedSessions: [],
+      waitingListSessions: [],
+    },
+  ],
+}
 
 const openModal = () => {
   const btn = screen.getByRole('button', { name: /^ON WAITING LIST.*/ })
@@ -16,21 +67,21 @@ const openModal = () => {
   return userEvent.click(btn)
 }
 
-// const selectAttendee = attendeeName => {
-//   const btn = screen.getByRole('button', { name: attendeeName })
-//   expect(btn).toBeDefined()
-//   return userEvent.click(btn)
-// }
+const selectAttendeeCheckbox = attendeeName => {
+  const box = screen.getByRole('group', { name: attendeeName })
+  const checkbox = within(box).getByRole('checkbox')
+  return userEvent.click(checkbox)
+}
 
 // const submitBooking = () => {
 //   const btn = screen.getByRole('button', { name: 'BOOK SELECTED' })
 //   return userEvent.click(btn)
 // }
 
-describe('Group Booking Modal Integration Test', () => {
+describe('Group Booking Modal - Integration', () => {
   beforeEach(async () => {
     window.scroll = jest.fn()
-    render(<Sessions sessionAgendaProps={waitingListCapacityTestData} />)
+    render(<Sessions sessionAgendaProps={waitingListData} />)
   })
 
   it('should open', async () => {
@@ -38,5 +89,15 @@ describe('Group Booking Modal Integration Test', () => {
     expect(
       await screen.findByText('Select sessions for your group:')
     ).toBeInTheDocument()
+  })
+
+  it('should add a user to the waiting list when capacity is empty', () => {
+    openModal()
+
+    selectAttendeeCheckbox('Ms. Teresa Waiting')
+
+    expect(screen.getAllByRole('checkbox', { checked: true }).length).toEqual(3)
+
+    expect(screen.getAllByText('On waiting list').length).toEqual(3)
   })
 })

--- a/src/components/__tests__/groupBooker.integration.js
+++ b/src/components/__tests__/groupBooker.integration.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import { onWaitingList } from 'SVEvfMocks/eventsforce/bookingStates/onWaitingList'
+import userEvent from '@testing-library/user-event'
+import { Sessions } from 'SVComponents/sessions'
+import { render, screen } from 'testUtils'
+
+const {
+  group: { capacity: waitingListCapacityTestData },
+} = onWaitingList
+
+import '@testing-library/jest-dom'
+
+const openModal = () => {
+  const btn = screen.getByRole('button', { name: /^ON WAITING LIST.*/ })
+  expect(btn).toBeDefined()
+  return userEvent.click(btn)
+}
+
+// const selectAttendee = attendeeName => {
+//   const btn = screen.getByRole('button', { name: attendeeName })
+//   expect(btn).toBeDefined()
+//   return userEvent.click(btn)
+// }
+
+// const submitBooking = () => {
+//   const btn = screen.getByRole('button', { name: 'BOOK SELECTED' })
+//   return userEvent.click(btn)
+// }
+
+describe('Group Booking Modal Integration Test', () => {
+  beforeEach(async () => {
+    window.scroll = jest.fn()
+    render(<Sessions sessionAgendaProps={waitingListCapacityTestData} />)
+  })
+
+  it('should open', async () => {
+    openModal()
+    expect(
+      await screen.findByText('Select sessions for your group:')
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/sessions.integration.js
+++ b/src/components/__tests__/sessions.integration.js
@@ -4,7 +4,7 @@ import { render } from 'testUtils'
 import '@testing-library/jest-dom'
 import testData from '../../mocks/eventsforce/testData.js'
 
-describe('Sessions', () => {
+describe('Sessions - Integration', () => {
   it('renders', async () => {
     render(<Sessions sessionAgendaProps={testData} />)
   })

--- a/src/components/booking/attendeeCheckboxItem.js
+++ b/src/components/booking/attendeeCheckboxItem.js
@@ -50,9 +50,7 @@ export const AttendeeCheckboxItem = props => {
 
   const textStyle = styles?.content?.right
 
-  const onCheckboxChange = event =>
-    console.log('selecting attendee with id', id) ||
-    onAttendeeSelected(id, { event })
+  const onCheckboxChange = event => onAttendeeSelected(id, { event })
 
   return (
     <View

--- a/src/components/booking/attendeeCheckboxItem.js
+++ b/src/components/booking/attendeeCheckboxItem.js
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react'
 import { EvfCheckbox } from 'SVComponents/checkbox/evfCheckbox'
+import { View } from '@keg-hub/keg-components'
 import { isEmpty, set } from '@keg-hub/jsutils'
 import { AttendeeCheckboxLabel } from './attendeeCheckboxLabel'
 
@@ -49,28 +50,35 @@ export const AttendeeCheckboxItem = props => {
 
   const textStyle = styles?.content?.right
 
-  const onCheckboxChange = event => onAttendeeSelected(id, { event })
+  const onCheckboxChange = event =>
+    console.log('selecting attendee with id', id) ||
+    onAttendeeSelected(id, { event })
 
   return (
-    <EvfCheckbox
-      id={checkboxId}
-      type={isWaiting ? 'alternate' : 'primary'}
-      styles={styles}
-      checked={checked}
-      onChange={onCheckboxChange}
-      disabled={disabled}
-      enableCheck={enableCheck}
-      rightClassName={textClassName}
-      RightComponent={props => (
-        <AttendeeCheckboxLabel
-          {...props}
-          htmlFor={checkboxId}
-          name={text}
-          textClassName={textClassName}
-          textStyle={textStyle}
-          waiting={isWaiting}
-        />
-      )}
-    />
+    <View
+      accessibilityRole='group'
+      accessibilityLabel={name}
+    >
+      <EvfCheckbox
+        id={checkboxId}
+        type={isWaiting ? 'alternate' : 'primary'}
+        styles={styles}
+        checked={checked}
+        onChange={onCheckboxChange}
+        disabled={disabled}
+        enableCheck={enableCheck}
+        rightClassName={textClassName}
+        RightComponent={props => (
+          <AttendeeCheckboxLabel
+            {...props}
+            htmlFor={checkboxId}
+            name={text}
+            textClassName={textClassName}
+            textStyle={textStyle}
+            waiting={isWaiting}
+          />
+        )}
+      />
+    </View>
   )
 }

--- a/src/components/booking/attendeeCheckboxItem.js
+++ b/src/components/booking/attendeeCheckboxItem.js
@@ -49,13 +49,15 @@ export const AttendeeCheckboxItem = props => {
 
   const textStyle = styles?.content?.right
 
+  const onCheckboxChange = event => onAttendeeSelected(id, { event })
+
   return (
     <EvfCheckbox
       id={checkboxId}
       type={isWaiting ? 'alternate' : 'primary'}
       styles={styles}
       checked={checked}
-      onChange={onAttendeeSelected}
+      onChange={onCheckboxChange}
       disabled={disabled}
       enableCheck={enableCheck}
       rightClassName={textClassName}

--- a/src/components/booking/attendeeCheckboxLabel.js
+++ b/src/components/booking/attendeeCheckboxLabel.js
@@ -84,6 +84,7 @@ export const AttendeeCheckboxLabel = props => {
         <Label
           htmlFor={htmlFor}
           className={textClassName}
+          role='button'
           style={textStyle}
           onPress={onPress}
         >

--- a/src/components/button/evfButton.js
+++ b/src/components/button/evfButton.js
@@ -125,6 +125,7 @@ export const EvfButton = props => {
       disabled={Boolean(disabled || isProcessing)}
       buttonType={buttonType}
       onClick={onBtnClick}
+      role='button'
     >
       <RenderChildren
         {...childProps}

--- a/src/components/checkbox/evfCheckbox.js
+++ b/src/components/checkbox/evfCheckbox.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React from 'react'
 import { Checkbox } from '@keg-hub/keg-components'
 import { useStyle } from '@keg-hub/re-theme'
 import { reStyle } from '@keg-hub/re-theme/reStyle'
@@ -21,8 +21,8 @@ const CheckIcon = reStyle(EVFIcons.Checkmark)(
  * @param {boolean} props.close - if true, the text will appear close to the checkbox. True by default.
  * @param {string} props.type - either primary or alternate (e.g. booking list vs waiting list colors)
  * @param {boolean} props.enableCheck - whether or not the checkbox can be selected
- * @param {string} props.id - an optional identifier passed to the callback to identify this checkbox
- * @param {Function?} props.onChange - callback handling a click, of form (id, { event, text }) -> {}
+ * @param {string} props.id - an optional DOM identifier
+ * @param {Function?} props.onChange - callback handling a click, of form ({ event, text }) -> {}
  * @param {string | Component} props.RightComponent - text or component adjacent to checkbox
  * @param {string} props.text - if RightComponent isn't provided, EvfCheckbox displays a Text element with this string as its content, to the right of the checkbox
  * @param {Object} props.styles
@@ -43,11 +43,6 @@ export const EvfCheckbox = props => {
     ...rest
   } = props
 
-  const handler = useCallback(event => onChange?.(id, { event, text }), [
-    onChange,
-    text,
-    id,
-  ])
   const checkboxStyles = useStyle(`checkboxGroup.item.${type}`, styles)
 
   return (
@@ -55,7 +50,7 @@ export const EvfCheckbox = props => {
       id={id}
       styles={checkboxStyles}
       RightComponent={RightComponent || text}
-      onChange={handler}
+      onChange={onChange}
       close={close}
       disableCheck={!enableCheck}
       CheckIcon={CheckIcon}

--- a/src/components/checkbox/evfCheckbox.js
+++ b/src/components/checkbox/evfCheckbox.js
@@ -48,6 +48,7 @@ export const EvfCheckbox = props => {
   return (
     <Checkbox
       id={id}
+      aria-label={id}
       styles={checkboxStyles}
       RightComponent={RightComponent || text}
       onChange={onChange}

--- a/src/components/form/label/label.web.js
+++ b/src/components/form/label/label.web.js
@@ -3,7 +3,10 @@ import { Text } from '@keg-hub/keg-components'
 import { reStyle } from '@keg-hub/re-theme/reStyle'
 import PropTypes from 'prop-types'
 
-const StyledLabel = reStyle('label')(() => ({ margin: 0, cursor: 'pointer' }))
+const StyledLabel = reStyle('label')(() => ({
+  margin: 0,
+  cursor: 'pointer',
+}))
 
 /**
  * Label component

--- a/src/contexts/booking/groupBookingReducer.js
+++ b/src/contexts/booking/groupBookingReducer.js
@@ -4,7 +4,7 @@ import { GroupBookingActionTypes } from './constants/groupBookingActionTypes'
 
 /**
  * Updates the list identified by listKey using the updateFn.
- * Also sets the next capacity and modified values.
+ * Also sets the next "capacity" and "modified" properties of state.
  * @param {Object} state - state of group booking reducer
  * @param {string} listKey - key name of the list to update
  * @param {Function} updateFn - fn of form (currentList) => nextList, returning the next list to reduce to

--- a/src/mocks/eventsforce/bookingStates/onWaitingList.js
+++ b/src/mocks/eventsforce/bookingStates/onWaitingList.js
@@ -134,9 +134,9 @@ export const onWaitingList = {
           waitingListSessions: ['1'],
         },
         {
-          bookedTicketIdentifier: '4',
+          bookedTicketIdentifier: '10',
           name: 'Ms. Teresa Waiting',
-          attendeeCategoryIdentifier: '1',
+          attendeeCategoryIdentifier: '2',
           bookedDays: [ 1, 2 ],
           bookedSessions: [],
           waitingListSessions: [],

--- a/src/mocks/eventsforce/bookingStates/onWaitingList.js
+++ b/src/mocks/eventsforce/bookingStates/onWaitingList.js
@@ -108,6 +108,7 @@ export const onWaitingList = {
             isUnlimited: false,
             remainingPlaces: 0,
             isWaitingListAvailable: true,
+            waitingListRemainingPlaces: 0,
           },
           price: {
             currency: 'USD',
@@ -131,6 +132,14 @@ export const onWaitingList = {
           bookedDays: [ 1, 2 ],
           bookedSessions: [],
           waitingListSessions: ['1'],
+        },
+        {
+          bookedTicketIdentifier: '4',
+          name: 'Ms. Teresa Waiting',
+          attendeeCategoryIdentifier: '1',
+          bookedDays: [ 1, 2 ],
+          bookedSessions: [],
+          waitingListSessions: [],
         },
       ],
     },

--- a/src/mocks/eventsforce/evfModalBuilder.js
+++ b/src/mocks/eventsforce/evfModalBuilder.js
@@ -34,8 +34,6 @@ export const evfModalBuilder = parentProps => {
       <Modal
         {...parentProps}
         id='test-modal'
-        accessibilityRole='dialog'
-        accessibilityLabel='modal'
         isOpen={isOpen}
         toggle={toggle}
         size={size}

--- a/src/mocks/eventsforce/testData.js
+++ b/src/mocks/eventsforce/testData.js
@@ -192,12 +192,7 @@ export default {
       startDateTimeLocal: '2020-08-03 09:00:00',
       endDateTimeLocal: '2020-08-03 13:30:00',
       presenterIdentifiers: [ '1', '2' ],
-      labelIdentifiers: [
-        '1',
-        '2',
-        '3',
-        '4',
-      ],
+      labelIdentifiers: [ '1', '2', '3', '4' ],
       locationIdentifier: '1',
       liveVideoUrl: 'https://us02web.zoom.us/j/1234',
       recordedVideoUrl: 'https://www.youtube.com/watch?v=21X5lGlDOfg',
@@ -551,6 +546,14 @@ export default {
       bookedDays: [ 1, 2 ],
       bookedSessions: [ '3', '5' ],
     },
+    {
+      bookedTicketIdentifier: '10',
+      name: 'Ms. Teresa Waiting',
+      attendeeCategoryIdentifier: '2',
+      bookedDays: [ 1, 2 ],
+      bookedSessions: [],
+      waitingListSessions: [],
+    },
   ],
   bookedTickets: [
     { identifier: '1', ticketIdentifier: '34' },
@@ -567,6 +570,7 @@ export default {
         { identifier: '6', ticketIdentifier: '37' },
       ],
     },
+    { identifier: '10', ticketIdentifier: '38' },
   ],
   tickets: [
     {

--- a/src/models/attendee.js
+++ b/src/models/attendee.js
@@ -11,7 +11,8 @@ export class Attendee {
   /**
    * Attendee class model
    * @param {object} params
-   * @param {string=} params.bookedTicketIdentifier - booked ticket id
+   * @param {string=} params.bookedTicketIdentifier - booked ticket id. This functions as the unique id of the attendee.
+   * It also must correspond to an existing ticket, or the attendee will be omitted from the redux store.
    * @param {string=} params.name - attendee's name
    * @param {string=} params.attendeeCategoryIdentifier - attendee category id
    * @param {Array<number>=} params.bookedDays - list of days booked

--- a/types/efSessionAgenda.ts
+++ b/types/efSessionAgenda.ts
@@ -1,0 +1,129 @@
+// import { EfTicketInterface } from "./efTicketInterface"
+// import { EfBookedTicketInterface } from "./efBookedTicketInterface"
+// import { EfDateFormat, EfTimeFormat } from "./formElementQuestionInterface"
+
+export interface EfSessionAgenda {
+  agendaDays: EfAgendaDay[]
+  sessions: EfSession[]
+  locations: EfLocation[]
+  labels?: EfLabel[]
+  presenters?: EfPresenter[]
+}
+
+export interface SessionAgendaProps {
+  displayProperties?: EfAgendaDisplayProperties
+  settings: EfAgendaSettings
+  agendaDays: EfAgendaDay[]
+  presenters: EfPresenter[]
+  labels: EfLabel[]
+  locations: EfLocation[]
+  sessions: EfSession[]
+  attendees: EfSessionAttendee[]
+  bookedTickets?: EfBookedTicketInterface[] // Used to link the bookedTicketIdentifier for the attendee to the actual ticket
+  tickets?: EfTicketInterface[] //Used to get the name of the tickets
+
+  onSessionBookingRequest?: (
+    sessionIdentifer: EfSessionIdentifier,
+    attendeeBookedTicketIdentifiers: EfBookedTicketIdentifier[]
+  ) => Promise<null> // Resolved when the request is successfully completed or throws Error with reason for failure
+
+  onSessionWaitingListRequest?: (
+    sessionIdentifer: EfSessionIdentifier,
+    attendeeBookedTicketIdentifiers: EfBookedTicketIdentifier[]
+  ) => Promise<null> // Resolved when the request is successfully completed or throws Error with reason for failure
+
+  alert?: EfAlert // passes any messages from event handlers to component
+}
+
+export interface EfAgendaDisplayProperties {
+  dateFormat: EfDateFormat
+  timeFormat: EfTimeFormat
+}
+
+export interface EfAlert {
+  title?: string
+  message?: string
+  type: "error"
+}
+
+export interface EfAgendaDay {
+  dayNumber: number
+  date: string
+  dayName: string
+}
+
+export interface EfPresenter {
+  identifier: EfPresenterIdentifier
+  title: string //Mr, mrs, Dr, etc max 50 characters
+  firstname: string //Max 50 characters
+  lastname: string //Max 50 characters
+  email: string //email address
+  jobtitle: string
+  company: string
+  photographUrl?: string // Url of presenters photo
+  biography: string // Max 10,000 characters
+}
+
+export interface EfAgendaSettings {
+  showLocationInAgenda: boolean
+  showPresentersInAgenda: boolean
+}
+
+export interface EfLabel {
+  identifier: EfLabelIdentifier
+  name: string
+  className: string
+}
+export interface EfLocation {
+  identifier: EfLocationIdentifier
+  name: string
+}
+
+export interface EfSession {
+  identifier: EfSessionIdentifier
+  name: string
+  summary: string
+  dayNumber: EfDayNumber
+  startDateTimeLocal: string // In the time zone of the event E.g. "2020-08-03 14:40:00"
+  endDateTimeLocal: string // In the time zone of the event E.g. "2020-08-03 15:40:00"
+  allowBooking?: boolean
+  presenterIdentifiers?: EfPresenterIdentifier[]
+  labelIdentifiers?: EfLabelIdentifier[]
+  locationIdentifier?: EfLocationIdentifier
+  liveVideoUrl?: string // Url for the live stream
+  recordedVideoUrl?: string // Url for the recorded video
+  price?: {
+    currency: string // ISO 4217
+    amount: number
+  }
+  restrictToAttendeeCategories?: EfAttendeeCategoryIdentifier[]
+  capacity?: {
+    isUnlimited: boolean
+    remainingPlaces?: number // Only populated if isUnlimited = false
+    isWaitingListAvailable?: boolean // Only populated if isUnlimited = false
+    waitingListRemainingPlaces?: number
+  }
+}
+
+export interface EfSessionAttendee {
+  bookedTicketIdentifier: EfBookedTicketIdentifier
+  name: string
+  attendeeCategoryIdentifier: EfAttendeeCategoryIdentifier
+  bookedDays: EfDayNumber[]
+  bookedSessions: EfSessionIdentifier[]
+  waitingListSessions: EfSessionIdentifier[]
+}
+
+export type EfAttendeeCategoryIdentifier = string
+
+export type EfBookedTicketIdentifier = string
+
+export type EfDayNumber = number
+
+export type EfPresenterIdentifier = string
+
+export type EfLocationIdentifier = string
+
+export type EfLabelIdentifier = string
+
+export type EfSessionIdentifier = string

--- a/types/exampleSessionData.ts
+++ b/types/exampleSessionData.ts
@@ -1,0 +1,345 @@
+import { SessionAgendaProps } from "../models/efSessionAgenda"
+import { EfTicketType } from "../models/efTicketInterface"
+import { EfTimeFormat } from "../models/formElementQuestionInterface"
+
+export const exampleSessionData: SessionAgendaProps = {
+  displayProperties: {
+    dateFormat: "MM/dd/yyyy",
+    timeFormat: EfTimeFormat.Twelve
+  },
+  settings: {
+    showLocationInAgenda: true,
+    showPresentersInAgenda: true
+  },
+  agendaDays: [
+    {
+      dayNumber: 1,
+      date: "2020-07-17",
+      dayName: "First day"
+    },
+    {
+      dayNumber: 2,
+      date: "2020-07-18",
+      dayName: "Day 2"
+    },
+    {
+      dayNumber: 3,
+      date: "2020-07-19",
+      dayName: "Third day"
+    }
+  ],
+  presenters: [
+    {
+      identifier: "1",
+      title: "Mr",
+      firstname: "Frank",
+      lastname: "Macloud",
+      email: "f.macloud@test.tes",
+      jobtitle: "Careers Advisor",
+      company: "Infinite Wealth",
+      photographUrl:
+        "https://47ddc71556b359d028bd-d91a48d103994bcfc502e0439b859d74.ssl.cf3.rackcdn.com/ef-iij5tpq56zja/noevent/personal/679/wvBcFJAn5jU0wAzmq3g6553149064133/avatar_people_person_business_.jpg",
+      biography:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+    },
+    {
+      identifier: "2",
+      title: "Ms",
+      firstname: "Cynthia",
+      lastname: "O'Connor",
+      email: "c.o'connor@test.tes",
+      jobtitle: "Marketing Manager",
+      company: "Scaffolding Solutions Ltd",
+      biography: ""
+    }
+  ],
+  labels: [
+    {
+      identifier: "1",
+      name: "important",
+      className: "ef-agenda-label-206"
+    },
+    {
+      identifier: "2",
+      name: "not so important",
+      className: "ef-agenda-label-207"
+    }
+  ],
+  locations: [
+    {
+      identifier: "1",
+      name: "The Atrium"
+    },
+    {
+      identifier: "2",
+      name: "Main Hall"
+    }
+  ],
+  sessions: [
+    {
+      identifier: "1",
+      name: "session with presenters and labels",
+      summary: "This is a session with both presenters and labels",
+      dayNumber: 1,
+      allowBooking: true,
+      startDateTimeLocal: "2020-08-03 13:00:00",
+      endDateTimeLocal: "2020-08-03 13:30:00",
+      presenterIdentifiers: ["1", "2"],
+      labelIdentifiers: ["1", "2"],
+      locationIdentifier: "1",
+      liveVideoUrl: "https://us02web.zoom.us/j/1234",
+      recordedVideoUrl: "https://www.youtube.com/watch?v=21X5lGlDOfg",
+      restrictToAttendeeCategories: [],
+      capacity: {
+        isUnlimited: true
+      },
+      price: {
+        currency: "USD",
+        amount: 923.0
+      }
+    },
+    {
+      identifier: "2",
+      name: "session at same time other session with presenters and labels",
+      summary: "",
+      dayNumber: 1,
+      allowBooking: true,
+      startDateTimeLocal: "2020-08-03 13:00:00",
+      endDateTimeLocal: "2020-08-03 13:30:00",
+      presenterIdentifiers: [],
+      labelIdentifiers: [],
+      locationIdentifier: "2",
+      liveVideoUrl: "",
+      recordedVideoUrl: "",
+      restrictToAttendeeCategories: [],
+      capacity: {
+        isUnlimited: true
+      }
+    },
+    {
+      identifier: "3",
+      name: "Session on day 2 limited capacity, no waiting list",
+      summary: "",
+      dayNumber: 2,
+      allowBooking: true,
+      startDateTimeLocal: "2020-08-04 09:00:00",
+      endDateTimeLocal: "2020-08-04 09:30:00",
+      presenterIdentifiers: [],
+      labelIdentifiers: [],
+      locationIdentifier: "2",
+      liveVideoUrl: "",
+      recordedVideoUrl: "",
+      restrictToAttendeeCategories: [],
+      capacity: {
+        isUnlimited: false,
+        remainingPlaces: 3,
+        isWaitingListAvailable: false
+      }
+    },
+    {
+      identifier: "4",
+      name: "Session on day 2 limited capacity, has waiting list",
+      summary: "",
+      dayNumber: 2,
+      allowBooking: true,
+      startDateTimeLocal: "2020-08-04 10:00:00",
+      endDateTimeLocal: "2020-08-04 10:30:00",
+      presenterIdentifiers: [],
+      labelIdentifiers: [],
+      locationIdentifier: "2",
+      liveVideoUrl: "",
+      recordedVideoUrl: "",
+      restrictToAttendeeCategories: [],
+      capacity: {
+        isUnlimited: false,
+        remainingPlaces: 3,
+        isWaitingListAvailable: true
+      }
+    },
+    {
+      identifier: "6",
+      name: "Session on day 2 full, has waiting list",
+      summary: "",
+      dayNumber: 2,
+      allowBooking: true,
+      startDateTimeLocal: "2020-08-04 11:00:00",
+      endDateTimeLocal: "2020-08-04 11:30:00",
+      presenterIdentifiers: [],
+      labelIdentifiers: [],
+      locationIdentifier: "2",
+      liveVideoUrl: "",
+      recordedVideoUrl: "",
+      restrictToAttendeeCategories: [],
+      capacity: {
+        isUnlimited: false,
+        remainingPlaces: 0,
+        isWaitingListAvailable: true
+      }
+    },
+    {
+      identifier: "7",
+      name: "Session on day 2 restricted to attendee category",
+      summary: "",
+      dayNumber: 2,
+      allowBooking: true,
+      startDateTimeLocal: "2020-08-04 11:00:00",
+      endDateTimeLocal: "2020-08-04 11:30:00",
+      presenterIdentifiers: [],
+      labelIdentifiers: [],
+      locationIdentifier: "2",
+      liveVideoUrl: "",
+      recordedVideoUrl: "",
+      restrictToAttendeeCategories: ["1"],
+      capacity: {
+        isUnlimited: true
+      }
+    },
+    {
+      identifier: "8",
+      name: "Session with no location, labels or presenters ",
+      summary: "",
+      dayNumber: 2,
+      allowBooking: true,
+      startDateTimeLocal: "2020-08-04 11:00:00",
+      endDateTimeLocal: "2020-08-04 11:30:00",
+      presenterIdentifiers: [],
+      labelIdentifiers: [],
+      liveVideoUrl: "",
+      recordedVideoUrl: "",
+      restrictToAttendeeCategories: [],
+      capacity: {
+        isUnlimited: true
+      }
+    },
+    {
+      identifier: "9",
+      name: "A session that cannot be booked",
+      summary: "",
+      dayNumber: 2,
+      allowBooking: false,
+      startDateTimeLocal: "2020-08-04 11:00:00",
+      endDateTimeLocal: "2020-08-04 11:30:00",
+      presenterIdentifiers: [],
+      labelIdentifiers: [],
+      liveVideoUrl: "",
+      recordedVideoUrl: "",
+      restrictToAttendeeCategories: [],
+      capacity: {
+        isUnlimited: true
+      }
+    },
+    {
+      identifier: "10",
+      name: "Session with waiting list enabled and 4 remaining waiting list places",
+      summary: "",
+      dayNumber: 2,
+      allowBooking: true,
+      startDateTimeLocal: "2020-08-04 12:00:00",
+      endDateTimeLocal: "2020-08-04 12:30:00",
+      presenterIdentifiers: [],
+      labelIdentifiers: [],
+      liveVideoUrl: "",
+      recordedVideoUrl: "",
+      restrictToAttendeeCategories: [],
+      capacity: {
+        isUnlimited: false,
+        remainingPlaces: 0,
+        isWaitingListAvailable: true,
+        waitingListRemainingPlaces: 4
+      }
+    },
+    {
+      identifier: "11",
+      name: "Session with waiting list enabled but no remaining waiting list places",
+      summary: "",
+      dayNumber: 2,
+      allowBooking: true,
+      startDateTimeLocal: "2020-08-04 12:00:00",
+      endDateTimeLocal: "2020-08-04 12:30:00",
+      presenterIdentifiers: [],
+      labelIdentifiers: [],
+      liveVideoUrl: "",
+      recordedVideoUrl: "",
+      restrictToAttendeeCategories: [],
+      capacity: {
+        isUnlimited: false,
+        remainingPlaces: 0,
+        isWaitingListAvailable: true,
+        waitingListRemainingPlaces: 0
+      }
+    }
+  ],
+
+  attendees: [
+    {
+      bookedTicketIdentifier: "1",
+      name: "Mr Frank Smith",
+      attendeeCategoryIdentifier: "1",
+      bookedDays: [1, 2],
+      bookedSessions: [],
+      waitingListSessions: []
+    },
+    {
+      bookedTicketIdentifier: "2",
+      name: "Mrs Penelope O'Connor",
+      attendeeCategoryIdentifier: "2",
+      bookedDays: [2],
+      bookedSessions: [],
+      waitingListSessions: []
+    },
+    {
+      bookedTicketIdentifier: "3",
+      name: "Dr Lucy Jones",
+      attendeeCategoryIdentifier: "1",
+      bookedDays: [1, 2],
+      bookedSessions: ["1", "3", "5"],
+      waitingListSessions: []
+    },
+    {
+      bookedTicketIdentifier: "5",
+      name: "Regular Attendee in group",
+      attendeeCategoryIdentifier: "1",
+      bookedDays: [1, 2],
+      bookedSessions: [],
+      waitingListSessions: []
+    },
+    {
+      bookedTicketIdentifier: "6",
+      name: "VIP in group",
+      attendeeCategoryIdentifier: "1",
+      bookedDays: [1, 2],
+      bookedSessions: [],
+      waitingListSessions: []
+    }
+  ],
+  bookedTickets: [
+    { identifier: "1", ticketIdentifier: "34" },
+    { identifier: "2", ticketIdentifier: "37" },
+    { identifier: "3", ticketIdentifier: "37" },
+    {
+      identifier: "4",
+      ticketIdentifier: "39",
+      bookedSubTickets: [{ identifier: "5", ticketIdentifier: "34" }, { identifier: "6", ticketIdentifier: "37" }]
+    }
+  ],
+  tickets: [
+    {
+      ticketType: EfTicketType.Person,
+      identifier: "34",
+      name: "Regular Attendee",
+      displayOrder: 1
+    },
+    {
+      ticketType: EfTicketType.Person,
+      identifier: "37",
+      name: "VIP",
+      displayOrder: 2
+    },
+    {
+      ticketType: EfTicketType.Group,
+      identifier: "39",
+      name: "Group",
+      displayOrder: 3
+    }
+  ]
+}


### PR DESCRIPTION
> Note: I will be branching off of this for ZEN-669, so please do not postpone review
## Context

* As I was working on `ZEN-669`, I noticed that we had actually broken the group booking modal in recent commits on develop.
* Furthermore, the group booker lacked any integration tests, so I wanted to correct that

## Updates

* `src/components/__tests__/groupBooker.integration.js`
  * Add some integration tests for the group booker. This is by no means exhaustive, but it's a good start.
* `src/components/booking/attendeeCheckboxItem.js`
  * Fix the bug in which the event handler for checkbox-click was not being passed the attendee id but rather the DOM element's id, which had additional text in it.
  * Wrapped the component in a `View` to that I could add some accessibility metadata
* `src/components/booking/attendeeCheckboxLabel.js`, `src/components/button/evfButton.js`
  * added an accessibility role
  * I used the `role` attribute, rather than `accessibilityRole`, because this component actually isn't a react-native one. The build exports a purely-web component (when running on web), so it's not react-native-web at all :| 
* `src/components/checkbox/evfCheckbox.js`
  * more bug fixing and better docs and better accessibility
* `types/efSessionAgenda.ts`
  * added the latest interface file

## Testing
* Ensure all the jest tests pass

